### PR TITLE
Update pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,7 +36,7 @@ Changelog = "https://github.com/GermanHeim/globalsearch-rs/releases"
 [tool.maturin]
 features = ["pyo3/extension-module"]
 module-name = "pyglobalsearch"
-exclude = ["tests/*", "docs/*"]
+exclude = [{ path = "/README.md", format = "sdist" }, "tests/*", "docs/*"]
 
 [tool.mypy]
 plugins = ["numpy.typing.mypy_plugin"]


### PR DESCRIPTION
## 📝 Description

- Adds the `./python/README.md` to `pyproject.toml`.
- Adds license definition to be MIT (We can't add the license file as it is in the parent directory, and it is currently not supported by `maturin`)
- Adds more project URLs
- Exclude texts and docs from builds

## 🔗 Related Issues

Closes https://github.com/GermanHeim/globalsearch-rs/issues/5 (Related to https://github.com/openjournals/joss-reviews/issues/9143)
