### PR TITLE
run cargo fmt

### DIFF
--- a/benches/batch_iterations.rs
+++ b/benches/batch_iterations.rs
@@ -1,27 +1,33 @@
 //! # Benchmarking batch_iterations with different batch sizes
 //! and comparing sequential vs parallel execution.
-//! 
+//!
 //! This benchmark evaluates the performance impact of the `batch_iterations`
 //! feature in the OQNLP algorithm using the Six-Hump Camel function and a more
 //! computationally expensive problem.
-//! 
+//!
 //! ## Batch Sizes Tested
 //! - 1 (sequential, no parallelism)
 //! - 4 (moderate parallelism)
 //! - 8 (high parallelism)
 //! - 16 (very high parallelism)
-//! 
+//!
 //! Run the benchmark with:
 //! ```bash
 //! cargo bench --features rayon --bench batch_iterations
 //! ```
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use globalsearch::{problem::Problem, oqnlp::OQNLP, types::{OQNLPParams, EvaluationError}};
+use globalsearch::{
+    oqnlp::OQNLP,
+    problem::Problem,
+    types::{EvaluationError, OQNLPParams},
+};
 use ndarray::{array, Array1, Array2};
 use std::hint::black_box;
 
 #[cfg(not(feature = "rayon"))]
-compile_error!("This benchmark requires the 'rayon' feature. Run with: cargo bench --features rayon");
+compile_error!(
+    "This benchmark requires the 'rayon' feature. Run with: cargo bench --features rayon"
+);
 
 // Six-Hump Camel problem for benchmarking
 #[derive(Clone)]
@@ -51,7 +57,8 @@ impl Problem for ExpensiveProblem {
         // Add computational overhead to make parallelization beneficial
         let mut result = 0.0;
         for i in 0..x.len() {
-            for j in 0..100 {  // Add computational overhead
+            for j in 0..100 {
+                // Add computational overhead
                 result += (x[i] * j as f64).sin().powi(2) + (x[i] * j as f64).cos().powi(2);
             }
         }
@@ -59,14 +66,19 @@ impl Problem for ExpensiveProblem {
     }
 
     fn variable_bounds(&self) -> Array2<f64> {
-        array![[-5.0 + 1.0, 5.0 + 1.0], [-5.0 + 1.0, 5.0 + 1.0], [-5.0 + 1.0, 5.0 + 1.0], [-5.0 + 1.0, 5.0 + 1.0]]
+        array![
+            [-5.0 + 1.0, 5.0 + 1.0],
+            [-5.0 + 1.0, 5.0 + 1.0],
+            [-5.0 + 1.0, 5.0 + 1.0],
+            [-5.0 + 1.0, 5.0 + 1.0]
+        ]
     }
 }
 
 fn benchmark_batch_iterations_sixhump(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_iterations_sixhump");
     group.measurement_time(std::time::Duration::from_secs(120));
-    
+
     let problem = SixHumpCamel;
     let base_params = OQNLPParams {
         iterations: 2500,
@@ -76,10 +88,14 @@ fn benchmark_batch_iterations_sixhump(c: &mut Criterion) {
 
     // Test different batch sizes
     let batch_sizes = vec![1, 4, 8, 16];
-    
+
     for &batch_size in &batch_sizes {
-        let batch_type = if batch_size == 1 { "sequential" } else { "parallel" };
-        
+        let batch_type = if batch_size == 1 {
+            "sequential"
+        } else {
+            "parallel"
+        };
+
         group.bench_with_input(
             BenchmarkId::new(batch_type, batch_size),
             &batch_size,
@@ -90,7 +106,7 @@ fn benchmark_batch_iterations_sixhump(c: &mut Criterion) {
                         let mut oqnlp = OQNLP::new(problem.clone(), base_params.clone())
                             .unwrap()
                             .batch_iterations(batch_size);
-                        
+
                         black_box(oqnlp.run().unwrap())
                     }
                     #[cfg(not(feature = "rayon"))]
@@ -102,14 +118,14 @@ fn benchmark_batch_iterations_sixhump(c: &mut Criterion) {
             },
         );
     }
-    
+
     group.finish();
 }
 
 fn benchmark_batch_iterations_expensive(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_iterations_expensive");
     group.measurement_time(std::time::Duration::from_secs(120));
-    
+
     let problem = ExpensiveProblem;
     let base_params = OQNLPParams {
         iterations: 2500,
@@ -119,10 +135,14 @@ fn benchmark_batch_iterations_expensive(c: &mut Criterion) {
 
     // Test different batch sizes for expensive problem
     let batch_sizes = vec![1, 4, 8, 16];
-    
+
     for &batch_size in &batch_sizes {
-        let batch_type = if batch_size == 1 { "sequential" } else { "parallel" };
-        
+        let batch_type = if batch_size == 1 {
+            "sequential"
+        } else {
+            "parallel"
+        };
+
         group.bench_with_input(
             BenchmarkId::new(batch_type, batch_size),
             &batch_size,
@@ -133,14 +153,14 @@ fn benchmark_batch_iterations_expensive(c: &mut Criterion) {
                         let mut oqnlp = OQNLP::new(problem.clone(), base_params.clone())
                             .unwrap()
                             .batch_iterations(batch_size);
-                        
+
                         black_box(oqnlp.run().unwrap())
                     }
                 })
             },
         );
     }
-    
+
     group.finish();
 }
 

--- a/benches/parallel_performance.rs
+++ b/benches/parallel_performance.rs
@@ -10,17 +10,19 @@
 //! - **ScatterSearch Algorithm**: Core scatter search with parallel control
 //! - **Different Population Sizes**: Small, medium, and large populations
 //! - **Parallel vs Sequential**: Direct comparison of execution modes
-//! 
+//!
 //! Run the benchmark with:
 //! ```bash
 //! cargo bench --features rayon --bench parallel_performance
 //! ```
 #[cfg(not(feature = "rayon"))]
-compile_error!("This benchmark requires the 'rayon' feature. Run with: cargo bench --features rayon");
+compile_error!(
+    "This benchmark requires the 'rayon' feature. Run with: cargo bench --features rayon"
+);
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use globalsearch::scatter_search::ScatterSearch;
 use globalsearch::problem::Problem;
+use globalsearch::scatter_search::ScatterSearch;
 use globalsearch::types::{EvaluationError, OQNLPParams};
 use ndarray::{array, Array1, Array2};
 use std::hint::black_box;
@@ -73,7 +75,7 @@ fn bench_scatter_search_parallel_vs_sequential(c: &mut Criterion) {
         population_size: 5000,
         ..OQNLPParams::default()
     };
-    
+
     c.bench_function("scatter_search_parallel", |b| {
         b.iter(|| {
             let problem = SixHumpCamel;
@@ -84,7 +86,7 @@ fn bench_scatter_search_parallel_vs_sequential(c: &mut Criterion) {
             black_box(result);
         });
     });
-    
+
     c.bench_function("scatter_search_sequential", |b| {
         b.iter(|| {
             let problem = SixHumpCamel;
@@ -103,7 +105,7 @@ fn bench_parallel_overhead_small_scale(c: &mut Criterion) {
         population_size: 100, // Small population where overhead should dominate
         ..OQNLPParams::default()
     };
-    
+
     c.bench_function("small_scale_parallel", |b| {
         b.iter(|| {
             let problem = DummyProblem::new(2);
@@ -114,7 +116,7 @@ fn bench_parallel_overhead_small_scale(c: &mut Criterion) {
             black_box(result);
         });
     });
-    
+
     c.bench_function("small_scale_sequential", |b| {
         b.iter(|| {
             let problem = DummyProblem::new(2);
@@ -133,7 +135,7 @@ fn bench_parallel_scaling_large_population(c: &mut Criterion) {
         population_size: 15000, // Large population to maximize parallel benefits
         ..OQNLPParams::default()
     };
-    
+
     c.bench_function("large_scale_parallel", |b| {
         b.iter(|| {
             let problem = SixHumpCamel;
@@ -144,7 +146,7 @@ fn bench_parallel_scaling_large_population(c: &mut Criterion) {
             black_box(result);
         });
     });
-    
+
     c.bench_function("large_scale_sequential", |b| {
         b.iter(|| {
             let problem = SixHumpCamel;
@@ -163,7 +165,7 @@ fn bench_computational_load_comparison(c: &mut Criterion) {
         population_size: 2000,
         ..OQNLPParams::default()
     };
-    
+
     // SixHump Camel (moderate computation)
     c.bench_function("sixhump_parallel", |b| {
         b.iter(|| {
@@ -175,7 +177,7 @@ fn bench_computational_load_comparison(c: &mut Criterion) {
             black_box(result);
         });
     });
-    
+
     c.bench_function("sixhump_sequential", |b| {
         b.iter(|| {
             let problem = SixHumpCamel;
@@ -186,7 +188,7 @@ fn bench_computational_load_comparison(c: &mut Criterion) {
             black_box(result);
         });
     });
-    
+
     // Dummy Problem (minimal computation)
     c.bench_function("dummy_parallel", |b| {
         b.iter(|| {
@@ -198,7 +200,7 @@ fn bench_computational_load_comparison(c: &mut Criterion) {
             black_box(result);
         });
     });
-    
+
     c.bench_function("dummy_sequential", |b| {
         b.iter(|| {
             let problem = DummyProblem::new(2);
@@ -217,7 +219,7 @@ criterion_group! {
         .warm_up_time(std::time::Duration::from_secs(3))
         .sample_size(15)
         .measurement_time(std::time::Duration::from_secs(60));
-    targets = 
+    targets =
         bench_scatter_search_parallel_vs_sequential,
         bench_parallel_overhead_small_scale,
         bench_parallel_scaling_large_population,

--- a/examples/basic_tutorial.rs
+++ b/examples/basic_tutorial.rs
@@ -6,7 +6,7 @@
 ///
 /// The Rosenbrock function is defined as:
 /// f(x, y) = (a - x)² + b(y - x²)²
-/// 
+///
 /// With a = 1 and b = 100, the function has a global minimum at (1, 1) with f(1, 1) = 0.
 /// This function is challenging because it has a narrow curved valley leading to the minimum.
 ///
@@ -15,15 +15,15 @@
 /// 2. Setting up basic optimization parameters  
 /// 3. Running the optimization
 /// 4. Interpreting results
-/// 
+///
 /// # References
-/// H. H. Rosenbrock, An Automatic Method for Finding the Greatest or Least Value of a Function, 
+/// H. H. Rosenbrock, An Automatic Method for Finding the Greatest or Least Value of a Function,
 /// The Computer Journal, Volume 3, Issue 3, 1960, Pages 175–184, https://doi.org/10.1093/comjnl/3.3.175
 use globalsearch::problem::Problem;
 use globalsearch::{
-    oqnlp::OQNLP,
     local_solver::builders::COBYLABuilder,
-    types::{EvaluationError, OQNLPParams,  LocalSolverType, SolutionSet},
+    oqnlp::OQNLP,
+    types::{EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
 };
 use ndarray::{array, Array1, Array2};
 
@@ -39,7 +39,7 @@ impl Rosenbrock {
     pub fn new(a: f64, b: f64) -> Self {
         Self { a, b }
     }
-    
+
     /// Create the standard Rosenbrock function with a=1, b=100
     pub fn standard() -> Self {
         Self::new(1.0, 100.0)
@@ -53,24 +53,24 @@ impl Problem for Rosenbrock {
         // Validate input dimensions
         if x.len() != 2 {
             return Err(EvaluationError::InvalidInput(
-                "Rosenbrock function requires exactly 2 variables".to_string()
+                "Rosenbrock function requires exactly 2 variables".to_string(),
             ));
         }
-        
+
         let x_val = x[0];
         let y_val = x[1];
-        
+
         let term1 = (self.a - x_val).powi(2);
         let term2 = self.b * (y_val - x_val.powi(2)).powi(2);
-        
+
         Ok(term1 + term2)
     }
 
     /// Define the search bounds: typically [-5, 5] for both variables
     fn variable_bounds(&self) -> Array2<f64> {
         array![
-            [-5.0, 10.0],  // x bounds
-            [-5.0, 10.0]   // y bounds  
+            [-5.0, 10.0], // x bounds
+            [-5.0, 10.0]  // y bounds
         ]
     }
 }
@@ -85,24 +85,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Step 2: Configure local optimization parameters
     let local_solver_config = COBYLABuilder::default()
-        .max_iter(500)                 // Maximum iterations for COBYLA
-        .initial_step_size(0.1)        // Initial step size for COBYLA
-        .ftol_rel(1e-10)               // Relative tolerance
-        .ftol_abs(1e-12)               // Absolute tolerance
+        .max_iter(500) // Maximum iterations for COBYLA
+        .initial_step_size(0.1) // Initial step size for COBYLA
+        .ftol_rel(1e-10) // Relative tolerance
+        .ftol_abs(1e-12) // Absolute tolerance
         .build();
-    
+
     // Step 3: Configure optimization parameters
     let params = OQNLPParams {
-        iterations: 750,         // Number of stage two iterations
-        population_size: 1500,   // Size of the scatter search population
-        wait_cycle: 15,          // Wait before updating search parameters
-        threshold_factor: 0.65,  // Merit filter sensitivity
-        distance_factor: 0.10,   // Minimum distance between solutions
+        iterations: 750,        // Number of stage two iterations
+        population_size: 1500,  // Size of the scatter search population
+        wait_cycle: 15,         // Wait before updating search parameters
+        threshold_factor: 0.65, // Merit filter sensitivity
+        distance_factor: 0.10,  // Minimum distance between solutions
         local_solver_type: LocalSolverType::COBYLA,
-        local_solver_config,     // Pass the COBYLA configuration
-        seed: 0,                 // Random seed for reproducibility
+        local_solver_config, // Pass the COBYLA configuration
+        seed: 0,             // Random seed for reproducibility
     };
-    
+
     println!("Optimization Settings:");
     println!("- Stage two iterations: {}", params.iterations);
     println!("- Population size: {}", params.population_size);
@@ -114,25 +114,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Starting optimization...");
     let mut oqnlp: OQNLP<Rosenbrock> = OQNLP::new(problem, params)?;
     let solution_set: SolutionSet = oqnlp.run()?;
-    
+
     // Step 5: Analyze the results
     println!("Optimization completed!");
     println!("{}", solution_set);
-    
+
     if let Some(best) = solution_set.best_solution() {
         println!("Detailed Analysis:");
         println!("=================");
-        
+
         let x_opt = best.point[0];
         let y_opt = best.point[1];
         let f_opt = best.objective;
-        
+
         println!("Distance from global minimum (1, 1):");
         let distance = ((x_opt - 1.0).powi(2) + (y_opt - 1.0).powi(2)).sqrt();
         println!("  Euclidean distance: {:.6}", distance);
         println!("  Error in objective: {:.8}", f_opt);
         println!();
-        
+
         // Evaluate how good the solution is
         if f_opt < 1e-4 {
             println!("Found global minimum with high precision");
@@ -146,6 +146,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         println!("No solutions found");
     }
-    
+
     Ok(())
 }

--- a/examples/catalytic_cracking.rs
+++ b/examples/catalytic_cracking.rs
@@ -1,17 +1,17 @@
 /// Catalytic Cracking of Gas Oil - Parameter Estimation Problem
-/// 
+///
 /// This example solves a parameter estimation problem for the catalytic cracking of gas
-/// oil into gas and other byproducts. The problem involves estimating three reaction 
-/// coefficients (θ₁, θ₂, θ₃) for a system of nonlinear ordinary 
+/// oil into gas and other byproducts. The problem involves estimating three reaction
+/// coefficients (θ₁, θ₂, θ₃) for a system of nonlinear ordinary
 /// differential equations (ODEs).
-/// 
+///
 /// The example comes from COPS 2.0: Large-Scale Optimization Problems (Problem #21)
 /// and it is based on the GAMS model (GASOIL.gms).
 ///
 /// ## Mathematical Model
 ///
 /// The catalytic cracking process is described by the following ODE system:
-/// 
+///
 /// dy₁/dt = -(θ₁ + θ₃) × y₁²
 /// dy₂/dt = θ₁ × y₁² - θ₂ × y₂
 ///
@@ -25,7 +25,7 @@
 /// ## Parameter Estimation Problem
 ///
 /// Given experimental observations at 21 time points from t=0.000 to t=0.950,
-/// we minimize the sum of squared residuals between the ODE solution and 
+/// we minimize the sum of squared residuals between the ODE solution and
 /// experimental data:
 ///
 /// minimize: Σᵢ Σⱼ (yⱼ(tᵢ; θ) - zᵢⱼ)²
@@ -42,10 +42,10 @@
 ///
 /// ## References
 ///
-/// - Dolan, E D, and More, J J, "Benchmarking Optimization Software with COPS." 
+/// - Dolan, E D, and More, J J, "Benchmarking Optimization Software with COPS."
 ///   Tech. rep., Mathematics and Computer Science Division, 2000.
-/// - Tjoa, I B, and Biegler, L T, "Simultaneous Solution and Optimization Strategies 
-///   for Parameter Estimation of Differential-Algebraic Equations Systems." 
+/// - Tjoa, I B, and Biegler, L T, "Simultaneous Solution and Optimization Strategies
+///   for Parameter Estimation of Differential-Algebraic Equations Systems."
 ///   Ind. Eng. Chem. Res. 30 (1991), 376-385.
 use globalsearch::problem::Problem;
 use globalsearch::{
@@ -70,26 +70,20 @@ impl ExperimentalData {
     fn new() -> Self {
         #[allow(clippy::approx_constant)]
         let times = vec![
-            0.000, 0.025, 0.050, 0.075, 0.100, 0.125,
-            0.150, 0.175, 0.200, 0.225, 0.250, 0.300,
-            0.350, 0.400, 0.450, 0.500, 0.550, 0.650,
-            0.750, 0.850, 0.950
+            0.000, 0.025, 0.050, 0.075, 0.100, 0.125, 0.150, 0.175, 0.200, 0.225, 0.250, 0.300,
+            0.350, 0.400, 0.450, 0.500, 0.550, 0.650, 0.750, 0.850, 0.950,
         ];
 
         #[allow(clippy::approx_constant)]
         let y1_observations = vec![
-            1.0000, 0.8105, 0.6208, 0.5258, 0.4345, 0.3903,
-            0.3342, 0.3034, 0.2735, 0.2405, 0.2283, 0.2071,
-            0.1669, 0.1530, 0.1339, 0.1265, 0.1200, 0.0990,
-            0.0870, 0.0770, 0.0690
+            1.0000, 0.8105, 0.6208, 0.5258, 0.4345, 0.3903, 0.3342, 0.3034, 0.2735, 0.2405, 0.2283,
+            0.2071, 0.1669, 0.1530, 0.1339, 0.1265, 0.1200, 0.0990, 0.0870, 0.0770, 0.0690,
         ];
 
         #[allow(clippy::approx_constant)]
         let y2_observations = vec![
-            0.0000, 0.2000, 0.2886, 0.3010, 0.3215, 0.3123,
-            0.2716, 0.2551, 0.2258, 0.1959, 0.1789, 0.1457,
-            0.1198, 0.0909, 0.0719, 0.0561, 0.0460, 0.0280,
-            0.0190, 0.0140, 0.0100
+            0.0000, 0.2000, 0.2886, 0.3010, 0.3215, 0.3123, 0.2716, 0.2551, 0.2258, 0.1959, 0.1789,
+            0.1457, 0.1198, 0.0909, 0.0719, 0.0561, 0.0460, 0.0280, 0.0190, 0.0140, 0.0100,
         ];
 
         ExperimentalData {
@@ -137,18 +131,18 @@ impl ODESolver {
     }
 
     /// Computes the right-hand side of the ODE system
-    /// 
+    ///
     /// Returns (dy₁/dt, dy₂/dt) given current state and parameters
     fn rhs(&self, state: ODEState, theta: &[f64]) -> (f64, f64) {
         let theta1 = theta[0];
-        let theta2 = theta[1]; 
+        let theta2 = theta[1];
         let theta3 = theta[2];
 
         let y1_squared = state.y1 * state.y1;
-        
+
         let dy1_dt = -(theta1 + theta3) * y1_squared;
         let dy2_dt = theta1 * y1_squared - theta2 * state.y2;
-        
+
         (dy1_dt, dy2_dt)
     }
 
@@ -156,7 +150,7 @@ impl ODESolver {
     fn step(&mut self, theta: &[f64]) {
         self.step_with_h(self.step_size, theta);
     }
-    
+
     /// Internal method: performs one step of 4th-order Runge-Kutta integration with specified step size
     /// This avoids mutating the struct's step_size field when adjusting for overshoot
     fn step_with_h(&mut self, h: f64, theta: &[f64]) {
@@ -164,54 +158,49 @@ impl ODESolver {
 
         // k1 = f(t, y)
         let (k1_y1, k1_y2) = self.rhs(y, theta);
-        
+
         // k2 = f(t + h/2, y + h*k1/2)
-        let y2_state = ODEState::new(
-            y.y1 + h * k1_y1 * 0.5,
-            y.y2 + h * k1_y2 * 0.5
-        );
+        let y2_state = ODEState::new(y.y1 + h * k1_y1 * 0.5, y.y2 + h * k1_y2 * 0.5);
         let (k2_y1, k2_y2) = self.rhs(y2_state, theta);
-        
-        // k3 = f(t + h/2, y + h*k2/2) 
-        let y3_state = ODEState::new(
-            y.y1 + h * k2_y1 * 0.5,
-            y.y2 + h * k2_y2 * 0.5
-        );
+
+        // k3 = f(t + h/2, y + h*k2/2)
+        let y3_state = ODEState::new(y.y1 + h * k2_y1 * 0.5, y.y2 + h * k2_y2 * 0.5);
         let (k3_y1, k3_y2) = self.rhs(y3_state, theta);
-        
+
         // k4 = f(t + h, y + h*k3)
-        let y4_state = ODEState::new(
-            y.y1 + h * k3_y1,
-            y.y2 + h * k3_y2
-        );
+        let y4_state = ODEState::new(y.y1 + h * k3_y1, y.y2 + h * k3_y2);
         let (k4_y1, k4_y2) = self.rhs(y4_state, theta);
-        
+
         // y_{n+1} = y_n + h/6 * (k1 + 2*k2 + 2*k3 + k4)
         self.state.y1 += h / 6.0 * (k1_y1 + 2.0 * k2_y1 + 2.0 * k3_y1 + k4_y1);
         self.state.y2 += h / 6.0 * (k1_y2 + 2.0 * k2_y2 + 2.0 * k3_y2 + k4_y2);
-        
+
         self.time += h;
     }
 
     /// Solves ODE system up to specified time points
-    /// 
+    ///
     /// Returns vectors of (y₁, y₂) values at the requested time points
-    fn solve_to_times(&mut self, target_times: &[f64], theta: &[f64]) -> Result<(Vec<f64>, Vec<f64>), String> {
+    fn solve_to_times(
+        &mut self,
+        target_times: &[f64],
+        theta: &[f64],
+    ) -> Result<(Vec<f64>, Vec<f64>), String> {
         let mut y1_results = Vec::with_capacity(target_times.len());
         let mut y2_results = Vec::with_capacity(target_times.len());
-        
+
         let mut time_index = 0;
-        
+
         // Add initial condition
         if !target_times.is_empty() && target_times[0] == 0.0 {
             y1_results.push(self.state.y1);
             y2_results.push(self.state.y2);
             time_index = 1;
         }
-        
+
         while time_index < target_times.len() {
             let target_time = target_times[time_index];
-            
+
             // Integrate until we reach or exceed the target time
             while self.time < target_time {
                 // Adjust step size if we would overshoot
@@ -225,12 +214,12 @@ impl ODESolver {
                     self.step(theta);
                 }
             }
-            
+
             y1_results.push(self.state.y1);
             y2_results.push(self.state.y2);
             time_index += 1;
         }
-        
+
         Ok((y1_results, y2_results))
     }
 }
@@ -264,36 +253,36 @@ impl CatalyticCracking {
         for &param in theta.iter() {
             if param <= 0.0 {
                 return Err(EvaluationError::InvalidInput(
-                    "All reaction rate coefficients must be positive".to_string()
+                    "All reaction rate coefficients must be positive".to_string(),
                 ));
             }
         }
 
         // Convert to slice for ODE solver
         let theta_slice = theta.as_slice().unwrap();
-        
+
         // Set up ODE solver with initial conditions
-        let initial_state = ODEState::new(1.0, 0.0);  // y₁(0) = 1, y₂(0) = 0
+        let initial_state = ODEState::new(1.0, 0.0); // y₁(0) = 1, y₂(0) = 0
         let mut solver = ODESolver::new(initial_state, self.integration_step_size);
-        
+
         // Solve ODE system at experimental time points
         let (y1_solution, y2_solution) = solver
             .solve_to_times(&self.experimental_data.times, theta_slice)
             .map_err(|_| EvaluationError::ObjectiveFunctionEvaluationFailed)?;
-        
+
         // Calculate sum of squared residuals
         let mut ssr = 0.0;
-        
+
         for i in 0..self.experimental_data.times.len() {
             // Residuals for y₁ (gas oil concentration)
             let y1_residual = y1_solution[i] - self.experimental_data.y1_observations[i];
             ssr += y1_residual * y1_residual;
-            
-            // Residuals for y₂ (gas/byproducts concentration)  
+
+            // Residuals for y₂ (gas/byproducts concentration)
             let y2_residual = y2_solution[i] - self.experimental_data.y2_observations[i];
             ssr += y2_residual * y2_residual;
         }
-        
+
         Ok(ssr)
     }
 }
@@ -302,11 +291,12 @@ impl Problem for CatalyticCracking {
     fn objective(&self, x: &Array1<f64>) -> Result<f64, EvaluationError> {
         // Validate input dimension - must have exactly 3 parameters
         if x.len() != 3 {
-            return Err(EvaluationError::InvalidInput(
-                format!("Expected 3 parameters (θ₁, θ₂, θ₃), got {}", x.len())
-            ));
+            return Err(EvaluationError::InvalidInput(format!(
+                "Expected 3 parameters (θ₁, θ₂, θ₃), got {}",
+                x.len()
+            )));
         }
-        
+
         self.residual_sum_of_squares(x)
     }
 
@@ -314,9 +304,9 @@ impl Problem for CatalyticCracking {
         // All parameters must be positive, with upper bounds based on typical values
         // for catalytic cracking reaction rates
         array![
-            [0.001, 100.0],  // θ₁: primary cracking rate
-            [0.001, 100.0],  // θ₂: secondary reaction rate  
-            [0.001, 100.0],  // θ₃: additional cracking rate
+            [0.001, 100.0], // θ₁: primary cracking rate
+            [0.001, 100.0], // θ₂: secondary reaction rate
+            [0.001, 100.0], // θ₃: additional cracking rate
         ]
     }
 }
@@ -339,7 +329,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Configure optimization parameters
     let params: OQNLPParams = OQNLPParams {
         iterations: 100,
-        population_size: 300,  
+        population_size: 300,
         wait_cycle: 15,
         threshold_factor: 0.15,
         distance_factor: 0.6,
@@ -348,10 +338,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let mut oqnlp: OQNLP<CatalyticCracking> = OQNLP::new(problem.clone(), params)?.verbose();
-    
+
     println!("Starting optimization...");
     println!();
-    
+
     let solution_set: SolutionSet = oqnlp.run()?;
 
     println!();
@@ -362,7 +352,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(best_solution) = solution_set.solutions.first() {
         let theta_opt = &best_solution.point;
         let ssr_min = best_solution.objective;
-        
+
         println!();
         println!("Best Parameter Estimates:");
         println!("=======================");
@@ -371,64 +361,75 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("θ₃ (additional cracking rate):  {:.6}", theta_opt[2]);
         println!();
         println!("Sum of Squared Residuals: {:.8}", ssr_min);
-        println!("Root Mean Square Error:   {:.6}", (ssr_min / (21.0 * 2.0)).sqrt());
-        
+        println!(
+            "Root Mean Square Error:   {:.6}",
+            (ssr_min / (21.0 * 2.0)).sqrt()
+        );
+
         // Validate solution by comparing with experimental data
         println!();
         println!("Model Validation:");
         println!("===============");
-        
+
         // Solve ODE with optimal parameters
         let initial_state = ODEState::new(1.0, 0.0);
         let mut solver = ODESolver::new(initial_state, problem.integration_step_size);
         let theta_slice = theta_opt.as_slice().unwrap();
-        
+
         match solver.solve_to_times(&problem.experimental_data.times, theta_slice) {
             Ok((y1_solution, y2_solution)) => {
                 println!("Time\tExp_y₁\tMod_y₁\tError₁\tExp_y₂\tMod_y₂\tError₂");
                 println!("----\t-----\t-----\t-----\t-----\t-----\t-----");
-                
+
                 let mut max_error_y1 = 0.0;
                 let mut max_error_y2 = 0.0;
-                
+
                 for i in 0..problem.experimental_data.times.len() {
                     let t = problem.experimental_data.times[i];
                     let exp_y1 = problem.experimental_data.y1_observations[i];
                     let mod_y1 = y1_solution[i];
                     let err_y1 = (mod_y1 - exp_y1).abs();
-                    
+
                     let exp_y2 = problem.experimental_data.y2_observations[i];
                     let mod_y2 = y2_solution[i];
                     let err_y2 = (mod_y2 - exp_y2).abs();
-                    
+
                     max_error_y1 = f64::max(max_error_y1, err_y1);
                     max_error_y2 = f64::max(max_error_y2, err_y2);
-                    
+
                     if i % 3 == 0 || i < 3 || i >= problem.experimental_data.times.len() - 3 {
-                        println!("{:.3}\t{:.4}\t{:.4}\t{:.4}\t{:.4}\t{:.4}\t{:.4}", 
-                                    t, exp_y1, mod_y1, err_y1, exp_y2, mod_y2, err_y2);
+                        println!(
+                            "{:.3}\t{:.4}\t{:.4}\t{:.4}\t{:.4}\t{:.4}\t{:.4}",
+                            t, exp_y1, mod_y1, err_y1, exp_y2, mod_y2, err_y2
+                        );
                     }
                 }
-                
+
                 println!("...\t(intermediate points omitted)\t...");
                 println!();
                 println!("Maximum Errors:");
                 println!("- Gas oil (y₁):      {:.6}", max_error_y1);
                 println!("- Gas/byproducts (y₂): {:.6}", max_error_y2);
-                
+
                 let conversion_rate = theta_opt[0] / (theta_opt[0] + theta_opt[2]);
-                println!("Primary conversion efficiency: {:.1}%", conversion_rate * 100.0);
-                
+                println!(
+                    "Primary conversion efficiency: {:.1}%",
+                    conversion_rate * 100.0
+                );
+
                 if theta_opt[1] > 0.0 {
                     let residence_time = 1.0 / theta_opt[1];
-                    println!("Gas/byproducts residence time: {:.3} time units", residence_time);
+                    println!(
+                        "Gas/byproducts residence time: {:.3} time units",
+                        residence_time
+                    );
                 }
             }
             Err(e) => {
                 println!("Error in solution validation: {}", e);
             }
         }
-        
+
         // Compare with GAMS reference solution
         println!();
         println!("GAMS Reference Solution Comparison:");
@@ -438,33 +439,41 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         println!("Parameter\tGAMS\t\tRust\t\tDifference\tRel. Error (%)");
         println!("---------\t----\t\t----\t\t----------\t--------------");
-        
+
         for i in 0..gams_theta.len() {
             let param_names = ["θ₁", "θ₂", "θ₃"];
             let gams_val = gams_theta[i];
             let rust_val = theta_opt[i];
             let diff = rust_val - gams_val;
             let rel_error = (diff / gams_val) * 100.0;
-            
-            println!("{}\t\t{:.3}\t\t{:.3}\t\t{:.6}\t{:.4}", 
-                     param_names[i], gams_val, rust_val, diff, rel_error);
+
+            println!(
+                "{}\t\t{:.3}\t\t{:.3}\t\t{:.6}\t{:.4}",
+                param_names[i], gams_val, rust_val, diff, rel_error
+            );
         }
-        
+
         // Calculate GAMS solution SSR for comparison
         let gams_theta_array = Array1::from(gams_theta.to_vec());
         match problem.residual_sum_of_squares(&gams_theta_array) {
             Ok(gams_ssr) => {
                 let rust_ssr = best_solution.objective;
                 let ssr_improvement = ((gams_ssr - rust_ssr) / gams_ssr) * 100.0;
-                
+
                 println!();
                 println!("Objective Function Comparison:");
                 println!("GAMS SSR:     {:.8}", gams_ssr);
                 println!("Rust SSR:     {:.8}", rust_ssr);
-                println!("Improvement:  {:.6}% ({} SSR)", 
-                            ssr_improvement.abs(), 
-                            if rust_ssr < gams_ssr { "lower" } else { "higher" });
-                
+                println!(
+                    "Improvement:  {:.6}% ({} SSR)",
+                    ssr_improvement.abs(),
+                    if rust_ssr < gams_ssr {
+                        "lower"
+                    } else {
+                        "higher"
+                    }
+                );
+
                 // Statistical significance test
                 let ssr_ratio = rust_ssr / gams_ssr;
                 if ssr_ratio < 0.999 {

--- a/examples/constrained_optimization.rs
+++ b/examples/constrained_optimization.rs
@@ -5,7 +5,7 @@
 ///
 /// Problem: Minimize f(x,y) = (x-1)² + (y-1)² subject to:
 /// - x + y ≤ 1.5 (linear constraint)
-/// - x² + y² ≥ 0.5 (nonlinear constraint) 
+/// - x² + y² ≥ 0.5 (nonlinear constraint)
 /// - 0 ≤ x ≤ 2, 0 ≤ y ≤ 2 (box constraints)
 ///
 /// This is a circle-packing style problem where we want to minimize distance
@@ -33,25 +33,25 @@ impl Problem for ConstrainedProblem {
     fn objective(&self, x: &Array1<f64>) -> Result<f64, EvaluationError> {
         if x.len() != 2 {
             return Err(EvaluationError::InvalidInput(
-                "Problem requires exactly 2 variables".to_string()
+                "Problem requires exactly 2 variables".to_string(),
             ));
         }
-        
+
         let x_val = x[0];
         let y_val = x[1];
-        
+
         // Minimize squared distance from (1, 1)
         Ok((x_val - 1.0).powi(2) + (y_val - 1.0).powi(2))
     }
-    
+
     /// Box constraints: 0 ≤ x ≤ 2, 0 ≤ y ≤ 2
     fn variable_bounds(&self) -> Array2<f64> {
         array![
-            [0.0, 2.0],  // x bounds
-            [0.0, 2.0]   // y bounds
+            [0.0, 2.0], // x bounds
+            [0.0, 2.0]  // y bounds
         ]
     }
-    
+
     /// General constraints (only supported by COBYLA)
     /// Return value ≥ 0 means constraint is satisfied
     /// Return value < 0 means constraint is violated
@@ -59,8 +59,7 @@ impl Problem for ConstrainedProblem {
         vec![
             // Constraint 1: x + y ≤ 1.5  ⇒  1.5 - x - y ≥ 0
             |x: &[f64], _: &mut ()| 1.5 - x[0] - x[1],
-            
-            // Constraint 2: x² + y² ≥ 0.5  ⇒  x² + y² - 0.5 ≥ 0  
+            // Constraint 2: x² + y² ≥ 0.5  ⇒  x² + y² - 0.5 ≥ 0
             |x: &[f64], _: &mut ()| x[0] * x[0] + x[1] * x[1] - 0.5,
         ]
     }
@@ -70,14 +69,14 @@ impl Problem for ConstrainedProblem {
 fn evaluate_constraints(point: &Array1<f64>) -> (Vec<f64>, bool) {
     let x = point[0];
     let y = point[1];
-    
+
     let constraint_values = vec![
-        1.5 - x - y,           // Linear constraint
-        x * x + y * y - 0.5,   // Nonlinear constraint
+        1.5 - x - y,         // Linear constraint
+        x * x + y * y - 0.5, // Nonlinear constraint
     ];
-    
+
     let all_satisfied = constraint_values.iter().all(|&c| c >= -1e-6);
-    
+
     (constraint_values, all_satisfied)
 }
 
@@ -92,15 +91,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     let problem = ConstrainedProblem;
-    
+
     // COBYLA configuration
     let cobyla_config = COBYLABuilder::default()
-        .max_iter(400)                 
+        .max_iter(400)
         .initial_step_size(0.1)
         .ftol_rel(1e-8)
         .ftol_abs(1e-10)
         .build();
-    
+
     let params = OQNLPParams {
         iterations: 15,
         population_size: 150,
@@ -119,48 +118,64 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     let mut oqnlp: OQNLP<ConstrainedProblem> = OQNLP::new(problem.clone(), params)?.verbose();
-    
+
     println!("Starting constrained optimization...");
     let solution_set: SolutionSet = oqnlp.run()?;
-    
+
     // Display results with constraint information
-    println!("{}", solution_set.display_with_constraints(&problem, Some(&[
-        "x + y ≤ 1.5",
-        "x² + y² ≥ 0.5"
-    ])));
-    
+    println!(
+        "{}",
+        solution_set.display_with_constraints(&problem, Some(&["x + y ≤ 1.5", "x² + y² ≥ 0.5"]))
+    );
+
     // Detailed analysis
     if let Some(best) = solution_set.best_solution() {
         let x_opt = best.point[0];
         let y_opt = best.point[1];
         let f_opt = best.objective;
-        
+
         println!();
         println!("Detailed Solution Analysis:");
         println!("==========================");
         println!("Optimal point: ({:.6}, {:.6})", x_opt, y_opt);
         println!("Objective value: {:.8}", f_opt);
-        
+
         // Check constraints manually
         let (constraint_values, all_satisfied) = evaluate_constraints(&best.point);
-        
+
         println!();
         println!("Constraint Verification:");
-        println!("- Linear constraint (x + y ≤ 1.5): {:.6} {}", 
-                constraint_values[0], 
-                if constraint_values[0] >= -1e-6 { "✓" } else { "✗" });
-        println!("- Nonlinear constraint (x² + y² ≥ 0.5): {:.6} {}", 
-                constraint_values[1], 
-                if constraint_values[1] >= -1e-6 { "✓" } else { "✗" });
-        
+        println!(
+            "- Linear constraint (x + y ≤ 1.5): {:.6} {}",
+            constraint_values[0],
+            if constraint_values[0] >= -1e-6 {
+                "✓"
+            } else {
+                "✗"
+            }
+        );
+        println!(
+            "- Nonlinear constraint (x² + y² ≥ 0.5): {:.6} {}",
+            constraint_values[1],
+            if constraint_values[1] >= -1e-6 {
+                "✓"
+            } else {
+                "✗"
+            }
+        );
+
         println!();
         if all_satisfied {
             println!("All constraints satisfied!");
-            
+
             // Analyze the solution quality
-            let distance_from_unconstrained = ((x_opt - 1.0).powi(2) + (y_opt - 1.0).powi(2)).sqrt();
-            println!("Distance from unconstrained optimum (1,1): {:.6}", distance_from_unconstrained);
-            
+            let distance_from_unconstrained =
+                ((x_opt - 1.0).powi(2) + (y_opt - 1.0).powi(2)).sqrt();
+            println!(
+                "Distance from unconstrained optimum (1,1): {:.6}",
+                distance_from_unconstrained
+            );
+
             // Check if we're at a constraint boundary (active constraints)
             println!();
             println!("Active Constraints (within tolerance 1e-3):");
@@ -170,7 +185,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             if constraint_values[1].abs() < 1e-3 {
                 println!("- Nonlinear constraint x² + y² ≥ 0.5 is ACTIVE");
             }
-            
+
             // Theoretical analysis
             println!();
             println!("Theoretical Analysis:");
@@ -178,26 +193,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("- Point (1, 1) violates x + y ≤ 1.5 since 1 + 1 = 2 > 1.5");
             println!("- Optimal solution should be on the constraint boundary x + y = 1.5");
             println!("- Among points on x + y = 1.5, closest to (1,1) is (0.75, 0.75)");
-            
+
             let theoretical_opt = (0.75_f64, 0.75_f64);
-            let theoretical_f = (theoretical_opt.0 - 1.0).powi(2) + (theoretical_opt.1 - 1.0).powi(2);
+            let theoretical_f =
+                (theoretical_opt.0 - 1.0).powi(2) + (theoretical_opt.1 - 1.0).powi(2);
             let error = (f_opt - theoretical_f).abs();
-            
-            println!("- Theoretical optimum: ({:.3}, {:.3}) with f = {:.6}", 
-                    theoretical_opt.0, theoretical_opt.1, theoretical_f);
+
+            println!(
+                "- Theoretical optimum: ({:.3}, {:.3}) with f = {:.6}",
+                theoretical_opt.0, theoretical_opt.1, theoretical_f
+            );
             println!("- Error from theoretical optimum: {:.8}", error);
-            
+
             if error < 1e-3 {
                 println!("Found theoretical optimum");
             } else if error < 1e-2 {
                 println!("Very good approximation to theoretical optimum");
             }
-            
         } else {
             println!("Some constraints are violated!");
             println!("This may indicate insufficient iterations or numerical issues.");
         }
     }
-    
+
     Ok(())
 }

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -70,7 +70,7 @@ pub enum BincodeError {
     /// Encoding error
     #[error("Encode error: {0}")]
     EncodeError(#[from] bincode::error::EncodeError),
-    
+
     /// Decoding error
     #[error("Decode error: {0}")]
     DecodeError(#[from] bincode::error::DecodeError),
@@ -239,8 +239,9 @@ impl CheckpointManager {
         }
 
         let encoded = fs::read(path)?;
-        let (checkpoint, _): (OQNLPCheckpoint, usize) = bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
-            .map_err(BincodeError::DecodeError)?;
+        let (checkpoint, _): (OQNLPCheckpoint, usize) =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map_err(BincodeError::DecodeError)?;
 
         Ok(checkpoint)
     }
@@ -352,8 +353,9 @@ pub fn read_checkpoint_file(path: &Path) -> Result<OQNLPCheckpoint, CheckpointEr
     }
 
     let encoded = fs::read(path)?;
-    let (checkpoint, _): (OQNLPCheckpoint, usize) = bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
-        .map_err(BincodeError::DecodeError)?;
+    let (checkpoint, _): (OQNLPCheckpoint, usize) =
+        bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+            .map_err(BincodeError::DecodeError)?;
 
     Ok(checkpoint)
 }

--- a/src/local_solver/builders.rs
+++ b/src/local_solver/builders.rs
@@ -191,20 +191,34 @@ impl std::fmt::Debug for LocalSolverConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LocalSolverConfig::LBFGS { .. } => f.debug_struct("LBFGS").finish_non_exhaustive(),
-            LocalSolverConfig::NelderMead { .. } => f.debug_struct("NelderMead").finish_non_exhaustive(),
-            LocalSolverConfig::SteepestDescent { .. } => f.debug_struct("SteepestDescent").finish_non_exhaustive(),
-            LocalSolverConfig::TrustRegion { .. } => f.debug_struct("TrustRegion").finish_non_exhaustive(),
-            LocalSolverConfig::NewtonCG { .. } => f.debug_struct("NewtonCG").finish_non_exhaustive(),
-            LocalSolverConfig::COBYLA { max_iter, initial_step_size, ftol_rel, ftol_abs, xtol_rel, xtol_abs } => {
-                f.debug_struct("COBYLA")
-                    .field("max_iter", max_iter)
-                    .field("initial_step_size", initial_step_size)
-                    .field("ftol_rel", ftol_rel)
-                    .field("ftol_abs", ftol_abs)
-                    .field("xtol_rel", xtol_rel)
-                    .field("xtol_abs", xtol_abs)
-                    .finish()
+            LocalSolverConfig::NelderMead { .. } => {
+                f.debug_struct("NelderMead").finish_non_exhaustive()
             }
+            LocalSolverConfig::SteepestDescent { .. } => {
+                f.debug_struct("SteepestDescent").finish_non_exhaustive()
+            }
+            LocalSolverConfig::TrustRegion { .. } => {
+                f.debug_struct("TrustRegion").finish_non_exhaustive()
+            }
+            LocalSolverConfig::NewtonCG { .. } => {
+                f.debug_struct("NewtonCG").finish_non_exhaustive()
+            }
+            LocalSolverConfig::COBYLA {
+                max_iter,
+                initial_step_size,
+                ftol_rel,
+                ftol_abs,
+                xtol_rel,
+                xtol_abs,
+            } => f
+                .debug_struct("COBYLA")
+                .field("max_iter", max_iter)
+                .field("initial_step_size", initial_step_size)
+                .field("ftol_rel", ftol_rel)
+                .field("ftol_abs", ftol_abs)
+                .field("xtol_rel", xtol_rel)
+                .field("xtol_abs", xtol_abs)
+                .finish(),
         }
     }
 }
@@ -212,60 +226,84 @@ impl std::fmt::Debug for LocalSolverConfig {
 impl Clone for LocalSolverConfig {
     fn clone(&self) -> Self {
         match self {
-            LocalSolverConfig::LBFGS { max_iter, tolerance_grad, tolerance_cost, history_size, l1_coefficient, line_search_params } => {
-                LocalSolverConfig::LBFGS {
-                    max_iter: *max_iter,
-                    tolerance_grad: *tolerance_grad,
-                    tolerance_cost: *tolerance_cost,
-                    history_size: *history_size,
-                    l1_coefficient: *l1_coefficient,
-                    line_search_params: line_search_params.clone(),
-                }
-            }
-            LocalSolverConfig::NelderMead { simplex_delta, sd_tolerance, max_iter, alpha, gamma, rho, sigma } => {
-                LocalSolverConfig::NelderMead {
-                    simplex_delta: *simplex_delta,
-                    sd_tolerance: *sd_tolerance,
-                    max_iter: *max_iter,
-                    alpha: *alpha,
-                    gamma: *gamma,
-                    rho: *rho,
-                    sigma: *sigma,
-                }
-            }
-            LocalSolverConfig::SteepestDescent { max_iter, line_search_params } => {
-                LocalSolverConfig::SteepestDescent {
-                    max_iter: *max_iter,
-                    line_search_params: line_search_params.clone(),
-                }
-            }
-            LocalSolverConfig::TrustRegion { trust_region_radius_method, max_iter, radius, max_radius, eta } => {
-                LocalSolverConfig::TrustRegion {
-                    trust_region_radius_method: trust_region_radius_method.clone(),
-                    max_iter: *max_iter,
-                    radius: *radius,
-                    max_radius: *max_radius,
-                    eta: *eta,
-                }
-            }
-            LocalSolverConfig::NewtonCG { max_iter, curvature_threshold, tolerance, line_search_params } => {
-                LocalSolverConfig::NewtonCG {
-                    max_iter: *max_iter,
-                    curvature_threshold: *curvature_threshold,
-                    tolerance: *tolerance,
-                    line_search_params: line_search_params.clone(),
-                }
-            }
-            LocalSolverConfig::COBYLA { max_iter, initial_step_size, ftol_rel, ftol_abs, xtol_rel, xtol_abs } => {
-                LocalSolverConfig::COBYLA {
-                    max_iter: *max_iter,
-                    initial_step_size: *initial_step_size,
-                    ftol_rel: *ftol_rel,
-                    ftol_abs: *ftol_abs,
-                    xtol_rel: *xtol_rel,
-                    xtol_abs: xtol_abs.clone(),
-                }
-            }
+            LocalSolverConfig::LBFGS {
+                max_iter,
+                tolerance_grad,
+                tolerance_cost,
+                history_size,
+                l1_coefficient,
+                line_search_params,
+            } => LocalSolverConfig::LBFGS {
+                max_iter: *max_iter,
+                tolerance_grad: *tolerance_grad,
+                tolerance_cost: *tolerance_cost,
+                history_size: *history_size,
+                l1_coefficient: *l1_coefficient,
+                line_search_params: line_search_params.clone(),
+            },
+            LocalSolverConfig::NelderMead {
+                simplex_delta,
+                sd_tolerance,
+                max_iter,
+                alpha,
+                gamma,
+                rho,
+                sigma,
+            } => LocalSolverConfig::NelderMead {
+                simplex_delta: *simplex_delta,
+                sd_tolerance: *sd_tolerance,
+                max_iter: *max_iter,
+                alpha: *alpha,
+                gamma: *gamma,
+                rho: *rho,
+                sigma: *sigma,
+            },
+            LocalSolverConfig::SteepestDescent {
+                max_iter,
+                line_search_params,
+            } => LocalSolverConfig::SteepestDescent {
+                max_iter: *max_iter,
+                line_search_params: line_search_params.clone(),
+            },
+            LocalSolverConfig::TrustRegion {
+                trust_region_radius_method,
+                max_iter,
+                radius,
+                max_radius,
+                eta,
+            } => LocalSolverConfig::TrustRegion {
+                trust_region_radius_method: trust_region_radius_method.clone(),
+                max_iter: *max_iter,
+                radius: *radius,
+                max_radius: *max_radius,
+                eta: *eta,
+            },
+            LocalSolverConfig::NewtonCG {
+                max_iter,
+                curvature_threshold,
+                tolerance,
+                line_search_params,
+            } => LocalSolverConfig::NewtonCG {
+                max_iter: *max_iter,
+                curvature_threshold: *curvature_threshold,
+                tolerance: *tolerance,
+                line_search_params: line_search_params.clone(),
+            },
+            LocalSolverConfig::COBYLA {
+                max_iter,
+                initial_step_size,
+                ftol_rel,
+                ftol_abs,
+                xtol_rel,
+                xtol_abs,
+            } => LocalSolverConfig::COBYLA {
+                max_iter: *max_iter,
+                initial_step_size: *initial_step_size,
+                ftol_rel: *ftol_rel,
+                ftol_abs: *ftol_abs,
+                xtol_rel: *xtol_rel,
+                xtol_abs: xtol_abs.clone(),
+            },
         }
     }
 }
@@ -1028,10 +1066,7 @@ pub struct COBYLABuilder {
 /// ```
 impl COBYLABuilder {
     /// Create a new COBYLA builder
-    pub fn new(
-        max_iter: u64,
-        initial_step_size: f64,
-    ) -> Self {
+    pub fn new(max_iter: u64, initial_step_size: f64) -> Self {
         COBYLABuilder {
             max_iter,
             initial_step_size,
@@ -1049,8 +1084,8 @@ impl COBYLABuilder {
             initial_step_size: self.initial_step_size,
             ftol_rel: self.ftol_rel.unwrap_or(1e-6),
             ftol_abs: self.ftol_abs.unwrap_or(1e-8),
-            xtol_rel: self.xtol_rel.unwrap_or(0.0),    // No default for x tolerances
-            xtol_abs: self.xtol_abs.unwrap_or_default(),  // Empty vector means no tolerance
+            xtol_rel: self.xtol_rel.unwrap_or(0.0), // No default for x tolerances
+            xtol_abs: self.xtol_abs.unwrap_or_default(), // Empty vector means no tolerance
         }
     }
 
@@ -1067,7 +1102,7 @@ impl COBYLABuilder {
     }
 
     /// Set the relative function tolerance for the COBYLA local solver
-    /// 
+    ///
     /// The local solver stops when the objective function changes by less than `ftol_rel * |f(x)|`
     pub fn ftol_rel(mut self, ftol_rel: f64) -> Self {
         self.ftol_rel = Some(ftol_rel);
@@ -1075,7 +1110,7 @@ impl COBYLABuilder {
     }
 
     /// Set the absolute function tolerance for the COBYLA local solver
-    /// 
+    ///
     /// The local solver stops when the objective function changes by less than `ftol_abs`
     pub fn ftol_abs(mut self, ftol_abs: f64) -> Self {
         self.ftol_abs = Some(ftol_abs);
@@ -1083,7 +1118,7 @@ impl COBYLABuilder {
     }
 
     /// Set the relative parameter tolerance for the COBYLA local solver
-    /// 
+    ///
     /// The local solver stops when all `x[i]` changes by less than `xtol_rel * x[i]`
     pub fn xtol_rel(mut self, xtol_rel: f64) -> Self {
         self.xtol_rel = Some(xtol_rel);
@@ -1091,7 +1126,7 @@ impl COBYLABuilder {
     }
 
     /// Set the absolute parameter tolerance for the COBYLA local solver
-    /// 
+    ///
     /// The local solver stops when all `x\[i\]` changes by less than `xtol_abs\[i\]`.
     /// Each element in the vector corresponds to the tolerance for that variable.
     /// If the vector is shorter than the number of variables, the last value is used
@@ -2183,10 +2218,10 @@ mod tests_builders {
             } => {
                 assert_eq!(max_iter, 300);
                 assert_eq!(initial_step_size, 0.5);
-                assert_eq!(ftol_rel, 1e-6);  // REL_TOL default
-                assert_eq!(ftol_abs, 1e-8);  // ABS_TOL default
-                assert_eq!(xtol_rel, 0.0);   // No default
-                assert_eq!(xtol_abs, Vec::<f64>::new());   // No default (empty vector)
+                assert_eq!(ftol_rel, 1e-6); // REL_TOL default
+                assert_eq!(ftol_abs, 1e-8); // ABS_TOL default
+                assert_eq!(xtol_rel, 0.0); // No default
+                assert_eq!(xtol_abs, Vec::<f64>::new()); // No default (empty vector)
             }
             _ => panic!("Expected COBYLA local solver"),
         }
@@ -2254,7 +2289,7 @@ mod tests_builders {
             .ftol_rel(1e-8)
             .xtol_abs(xtol_vec.clone())
             .build();
-        
+
         match cobyla {
             LocalSolverConfig::COBYLA {
                 max_iter,

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -31,14 +31,14 @@
 //! - **Purpose**: Defines the feasible region for optimization
 //!
 //! ### Constraints (Optional, only valid with the COBYLA local solver)
-//! - **Sign Convention**: 
+//! - **Sign Convention**:
 //!   - `g(x) ≥ 0`: Constraint satisfied
 //!   - `g(x) < 0`: Constraint violated
 //! - **Return Type**: Vector of constraint function closures
 //! - **Use Cases**: Nonlinear inequality constraints beyond simple bounds
 //!
 //! ## Example: Six-Hump Camel Function
-//! 
+//!
 //! ```rust
 //! /// References:
 //! ///
@@ -103,7 +103,7 @@ use ndarray::{Array1, Array2};
 /// The variable bounds are the lower and upper bounds for the optimization problem.
 ///
 /// Constraint functions for constrained optimization problems can also be defined using the `constraints` method.
-/// 
+///
 /// The default implementation of the gradient and hessian returns an error indicating the gradient and hessian are not implemented.
 /// Some local solvers require the gradient and hessian to be implemented, while for others it isn't needed.
 /// You should check the documentation of the local solver you are using to know if the gradient and hessian are needed.
@@ -146,30 +146,30 @@ pub trait Problem {
     ///
     /// Returns constraint functions in the format expected by optimization solvers.
     /// Function pointers that take (&[f64], &mut ()) and return f64.
-    /// 
-    /// **Sign Convention**: 
+    ///
+    /// **Sign Convention**:
     /// - **Positive or zero**: constraint satisfied  
     /// - **Negative**: constraint violated
-    /// 
+    ///
     /// The default implementation returns an empty vector (no constraints).
     ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use globalsearch::problem::Problem;
     /// use globalsearch::types::EvaluationError;
     /// use ndarray::Array1;
-    /// 
+    ///
     /// struct MyProblem;
     /// impl Problem for MyProblem {
     ///     fn objective(&self, x: &Array1<f64>) -> Result<f64, EvaluationError> {
     ///         Ok(x[0].powi(2) + x[1].powi(2))
     ///     }
-    /// 
+    ///
     ///     fn variable_bounds(&self) -> ndarray::Array2<f64> {
     ///         ndarray::array![[-1.0, 1.0], [-1.0, 1.0]]
     ///     }
-    /// 
+    ///
     ///     fn constraints(&self) -> Vec<fn(&[f64], &mut ()) -> f64> {
     ///         vec![
     ///             |x: &[f64], _: &mut ()| 1.0 - x[0] - x[1], // x[0] + x[1] <= 1.0 -> 1.0 - x[0] - x[1] >= 0

--- a/src/scatter_search.rs
+++ b/src/scatter_search.rs
@@ -145,7 +145,7 @@ impl<P: Problem + Sync + Send> ScatterSearch<P> {
     }
 
     /// Control whether parallel processing is enabled at runtime
-    /// 
+    ///
     /// This method allows you to disable parallel processing even when the `rayon` feature is enabled,
     /// which can be useful for:
     /// - Python bindings
@@ -183,13 +183,13 @@ impl<P: Problem + Sync + Send> ScatterSearch<P> {
             pb.set_description("Stage 1, found best solution");
             pb.update(1).expect("Failed to update progress bar");
         }
-        
+
         let reference_set_with_objectives: Vec<(Array1<f64>, f64)> = self
             .reference_set
             .into_iter()
             .zip(self.reference_set_objectives)
             .collect();
-            
+
         Ok((reference_set_with_objectives, best))
     }
 
@@ -207,13 +207,13 @@ impl<P: Problem + Sync + Send> ScatterSearch<P> {
         }
 
         self.diversify_reference_set(&mut ref_set)?;
-        
+
         // Evaluate objectives for the initial reference set
         let objectives: Vec<f64> = ref_set
             .iter()
             .map(|point| self.problem.objective(point))
             .collect::<Result<Vec<f64>, _>>()?;
-            
+
         self.reference_set = ref_set;
         self.reference_set_objectives = objectives;
 


### PR DESCRIPTION
## 📝 Description
Running `cargo fmt` on the codebase formats the code differently to what is present. I suggest a few options of how to proceed:

1. Define a `rustfmt.toml` file which specifies how to format. This could possibly be used to keep the current format.
2. If you decide to keep the current format, ignore this PR.
3. Add a github workflow which checks that formatting matches

```
$ cargo fmt --version
rustfmt 1.8.0-stable (1159e78c47 2025-09-14)
```
