### PR TITLE
Enforce clippy warnings as errors in CI workflows

### DIFF
--- a/.github/workflows/globalsearch-rs-CI.yml
+++ b/.github/workflows/globalsearch-rs-CI.yml
@@ -33,11 +33,11 @@ jobs:
         with:
           components: clippy
       - name: Clippy
-        run: cargo clippy --verbose
+        run: cargo clippy --verbose -- -D warnings
       - name: Clippy with rayon
-        run: cargo clippy --features "rayon" --verbose
+        run: cargo clippy --features "rayon" --verbose -- -D warnings
       - name: Clippy with checkpointing
-        run: cargo clippy --features "checkpointing" --verbose
+        run: cargo clippy --features "checkpointing" --verbose -- -D warnings
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/pyglobalsearch-ci.yml
+++ b/.github/workflows/pyglobalsearch-ci.yml
@@ -48,6 +48,17 @@ jobs:
           source .venv/bin/activate
           pytest tests/
 
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Clippy pyglobalsearch
+        run: cargo clippy --manifest-path python/Cargo.toml --verbose -- -D warnings
+
   fmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 📝 Description

Updated Rust CI workflows to run clippy with warnings, causing CI to fail on any lint warnings. Added a clippy job to the `pyglobalsearch` workflow to ensure Rust code in the Python bindings is also checked for lint warnings.

## 📋 Checklist

- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All tests pass (`cargo test`)