### PR TITLE
Update macOS runners in CI workflow

### DIFF
--- a/.github/workflows/maturin-ci.yml
+++ b/.github/workflows/maturin-ci.yml
@@ -118,9 +118,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64
-          - runner: macos-14
+          - runner: macos-15
             target: aarch64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Replaces macos-13 with macos-15-intel for x86_64 and macos-14 with macos-15 for aarch64 in the GitHub Actions workflow for maturin. The macOS 13 runner image will be retired by December 4th, 2025.
