### PR TITLE
Remove `local_solver_type` field from `OQNLPParams`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Or use `cargo add globalsearch` in your project directory.
 2. Set OQNLP parameters
 
    ```rust
-   use globalsearch::types::{LocalSolverType, OQNLPParams};
+   use globalsearch::types::OQNLPParams;
    use globalsearch::local_solver::builders::SteepestDescentBuilder;
 
    let params: OQNLPParams = OQNLPParams {
@@ -150,7 +150,6 @@ Or use `cargo add globalsearch` in your project directory.
        threshold_factor: 0.2,
        distance_factor: 0.75,
        population_size: 250,
-       local_solver_type: LocalSolverType::SteepestDescent,
        local_solver_config: SteepestDescentBuilder::default().build(),
        seed: 0,
    };
@@ -171,7 +170,6 @@ Or use `cargo add globalsearch` in your project directory.
        pub threshold_factor: f64,
        pub distance_factor: f64,
        pub population_size: usize,
-       pub local_solver_type: LocalSolverType,
        pub local_solver_config: LocalSolverConfig,
        pub seed: u64,
    }
@@ -206,7 +204,6 @@ Or use `cargo add globalsearch` in your project directory.
                 threshold_factor: 0.2,
                 distance_factor: 0.75,
                 population_size: 250,
-                local_solver_type: LocalSolverType::SteepestDescent,
                 local_solver_config: SteepestDescentBuilder::default().build(),
                 seed: 0,
             };

--- a/benches/six_hump_camel.rs
+++ b/benches/six_hump_camel.rs
@@ -15,7 +15,7 @@ use globalsearch::local_solver::builders::SteepestDescentBuilder;
 use globalsearch::problem::Problem;
 use globalsearch::{
     oqnlp::OQNLP,
-    types::{EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
+    types::{EvaluationError, OQNLPParams, SolutionSet},
 };
 use ndarray::{Array1, Array2, array};
 use std::hint::black_box;
@@ -50,7 +50,6 @@ fn six_hump_camel() -> Result<SolutionSet, Box<dyn std::error::Error>> {
         threshold_factor: 0.2,
         distance_factor: 0.75,
         population_size: 100,
-        local_solver_type: LocalSolverType::SteepestDescent,
         local_solver_config: SteepestDescentBuilder::default().build(),
         seed: 0,
     };

--- a/examples/1d-griewank.rs
+++ b/examples/1d-griewank.rs
@@ -14,7 +14,7 @@ use globalsearch::local_solver::builders::{HagerZhangBuilder, LBFGSBuilder};
 use globalsearch::problem::Problem;
 use globalsearch::{
     oqnlp::OQNLP,
-    types::{EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
+    types::{EvaluationError, OQNLPParams, SolutionSet},
 };
 use ndarray::{Array1, Array2, array};
 
@@ -45,7 +45,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         threshold_factor: 0.1,
         distance_factor: 0.75,
         population_size: 100,
-        local_solver_type: LocalSolverType::LBFGS,
         local_solver_config: LBFGSBuilder::default().build(),
         seed: 0,
     };
@@ -63,7 +62,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         threshold_factor: 0.1,
         distance_factor: 0.75,
         population_size: 500,
-        local_solver_type: LocalSolverType::LBFGS,
         local_solver_config: LBFGSBuilder::default()
             .max_iter(100)
             .history_size(15)

--- a/examples/3d-ackley.rs
+++ b/examples/3d-ackley.rs
@@ -15,7 +15,7 @@ use globalsearch::local_solver::builders::{HagerZhangBuilder, LBFGSBuilder};
 use globalsearch::problem::Problem;
 use globalsearch::{
     oqnlp::OQNLP,
-    types::{EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
+    types::{EvaluationError, OQNLPParams, SolutionSet},
 };
 use ndarray::{Array1, Array2, array};
 
@@ -86,7 +86,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         threshold_factor: 0.2,
         distance_factor: 0.75,
         population_size: 150,
-        local_solver_type: LocalSolverType::LBFGS,
         local_solver_config: LBFGSBuilder::default()
             .line_search_params(HagerZhangBuilder::default().build())
             .build(),

--- a/examples/basic_tutorial.rs
+++ b/examples/basic_tutorial.rs
@@ -23,7 +23,7 @@ use globalsearch::problem::Problem;
 use globalsearch::{
     local_solver::builders::COBYLABuilder,
     oqnlp::OQNLP,
-    types::{EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
+    types::{EvaluationError, OQNLPParams, SolutionSet},
 };
 use ndarray::{Array1, Array2, array};
 
@@ -98,15 +98,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wait_cycle: 15,         // Wait before updating search parameters
         threshold_factor: 0.65, // Merit filter sensitivity
         distance_factor: 0.10,  // Minimum distance between solutions
-        local_solver_type: LocalSolverType::COBYLA,
-        local_solver_config, // Pass the COBYLA configuration
-        seed: 0,             // Random seed for reproducibility
+        local_solver_config,    // Pass the COBYLA configuration
+        seed: 0,                // Random seed for reproducibility
     };
 
     println!("Optimization Settings:");
     println!("- Stage two iterations: {}", params.iterations);
     println!("- Population size: {}", params.population_size);
-    println!("- Local solver: {:?}", params.local_solver_type);
+    println!("- Local solver: {:?}", params.local_solver_type());
     println!("- Random seed: {}", params.seed);
     println!();
 

--- a/examples/checkpointing_example.rs
+++ b/examples/checkpointing_example.rs
@@ -12,7 +12,7 @@ use globalsearch::{
     local_solver::builders::NelderMeadBuilder,
     oqnlp::OQNLP,
     problem::Problem,
-    types::{CheckpointConfig, EvaluationError, LocalSolverType, OQNLPParams},
+    types::{CheckpointConfig, EvaluationError, OQNLPParams},
 };
 
 #[cfg(feature = "checkpointing")]
@@ -64,7 +64,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Configure OQNLP parameters for initial optimization
     let params = OQNLPParams {
-        local_solver_type: LocalSolverType::NelderMead,
         local_solver_config: NelderMeadBuilder::default().build(),
         iterations: 15, // Very few iterations to find only one solution initially
         population_size: 200, // Smaller population size

--- a/examples/checkpointing_population_size_expansion.rs
+++ b/examples/checkpointing_population_size_expansion.rs
@@ -11,7 +11,7 @@ use globalsearch::{
     local_solver::builders::LBFGSBuilder,
     oqnlp::OQNLP,
     problem::Problem,
-    types::{CheckpointConfig, EvaluationError, LocalSolverType, OQNLPParams},
+    types::{CheckpointConfig, EvaluationError, OQNLPParams},
 };
 
 #[cfg(feature = "checkpointing")]
@@ -66,7 +66,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wait_cycle: 10,
         threshold_factor: 0.2,
         distance_factor: 0.75,
-        local_solver_type: LocalSolverType::LBFGS,
         local_solver_config: LBFGSBuilder::default().build(),
         seed: 42,
     };
@@ -96,7 +95,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wait_cycle: 10,
         threshold_factor: 0.2,
         distance_factor: 0.75,
-        local_solver_type: LocalSolverType::LBFGS,
         local_solver_config: LBFGSBuilder::default().build(),
         seed: 42,
     };
@@ -128,7 +126,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wait_cycle: 10,
         threshold_factor: 0.2,
         distance_factor: 0.75,
-        local_solver_type: LocalSolverType::LBFGS,
         local_solver_config: LBFGSBuilder::default().build(),
         seed: 42,
     };

--- a/examples/constrained_optimization.rs
+++ b/examples/constrained_optimization.rs
@@ -20,7 +20,7 @@ use globalsearch::problem::Problem;
 use globalsearch::{
     local_solver::builders::COBYLABuilder,
     oqnlp::OQNLP,
-    types::{EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
+    types::{EvaluationError, OQNLPParams, SolutionSet},
 };
 use ndarray::{Array1, Array2, array};
 
@@ -106,7 +106,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wait_cycle: 5,
         threshold_factor: 0.1,
         distance_factor: 0.8,
-        local_solver_type: LocalSolverType::COBYLA,
         local_solver_config: cobyla_config,
         seed: 0,
     };

--- a/examples/cross_in_tray.rs
+++ b/examples/cross_in_tray.rs
@@ -14,7 +14,7 @@ use globalsearch::local_solver::builders::LBFGSBuilder;
 use globalsearch::problem::Problem;
 use globalsearch::{
     oqnlp::OQNLP,
-    types::{EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
+    types::{EvaluationError, OQNLPParams, SolutionSet},
 };
 use ndarray::{Array1, Array2, array};
 
@@ -113,7 +113,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         threshold_factor: 0.1,
         distance_factor: 0.75,
         population_size: 350,
-        local_solver_type: LocalSolverType::LBFGS,
         local_solver_config: LBFGSBuilder::default().build(),
         seed: 0,
     };

--- a/examples/extended_checkpointing.rs
+++ b/examples/extended_checkpointing.rs
@@ -11,7 +11,7 @@ use globalsearch::{
     local_solver::builders::{TrustRegionBuilder, TrustRegionRadiusMethod},
     oqnlp::OQNLP,
     problem::Problem,
-    types::{CheckpointConfig, EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
+    types::{CheckpointConfig, EvaluationError, OQNLPParams, SolutionSet},
 };
 
 #[cfg(feature = "checkpointing")]
@@ -105,7 +105,6 @@ fn run_optimization_stage(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Configure OQNLP parameters for this stage
     let params = OQNLPParams {
-        local_solver_type: LocalSolverType::TrustRegion,
         local_solver_config: TrustRegionBuilder::default()
             .method(TrustRegionRadiusMethod::Steihaug)
             .build(),

--- a/examples/shubert_observer.rs
+++ b/examples/shubert_observer.rs
@@ -28,7 +28,7 @@ use globalsearch::local_solver::builders::COBYLABuilder;
 use globalsearch::observers::Observer;
 use globalsearch::oqnlp::OQNLP;
 use globalsearch::problem::Problem;
-use globalsearch::types::{EvaluationError, LocalSolverType, OQNLPParams};
+use globalsearch::types::{EvaluationError, OQNLPParams};
 use ndarray::{Array1, Array2, array};
 
 /// Shubert function implementation
@@ -84,7 +84,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         threshold_factor: 0.3,
         distance_factor: 0.8,
         population_size: 13000,
-        local_solver_type: LocalSolverType::COBYLA,
         local_solver_config: COBYLABuilder::default().max_iter(75).initial_step_size(1.0).build(),
         seed: 0,
     };

--- a/examples/sixhumpcamel.rs
+++ b/examples/sixhumpcamel.rs
@@ -14,7 +14,7 @@ use globalsearch::local_solver::builders::SteepestDescentBuilder;
 use globalsearch::problem::Problem;
 use globalsearch::{
     oqnlp::OQNLP,
-    types::{EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
+    types::{EvaluationError, OQNLPParams, SolutionSet},
 };
 use ndarray::{Array1, Array2, array};
 
@@ -49,7 +49,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         threshold_factor: 0.2,
         distance_factor: 0.75,
         population_size: 250,
-        local_solver_type: LocalSolverType::SteepestDescent,
         local_solver_config: SteepestDescentBuilder::default().build(),
         seed: 0,
     };

--- a/python/examples/basic_tutorial.py
+++ b/python/examples/basic_tutorial.py
@@ -133,7 +133,6 @@ def main():
         result = gs.optimize(
             problem=problem,
             params=params,
-            local_solver="COBYLA",
             local_solver_config=local_solver_config,
             seed=0,  # For reproducible results
             verbose=True,  # Show progress during optimization

--- a/python/examples/constrained_optimization.py
+++ b/python/examples/constrained_optimization.py
@@ -54,7 +54,6 @@ def main():
     result = gs.optimize(
         problem=problem,
         params=params,
-        local_solver="COBYLA",
         local_solver_config=cobyla_config,
         verbose=True,
     )

--- a/python/examples/shubert_observer.py
+++ b/python/examples/shubert_observer.py
@@ -98,7 +98,6 @@ def main():
     result = gs.optimize(
         problem=problem,
         params=params,
-        local_solver="COBYLA",
         seed=0,
         local_solver_config=cobyla_config,
         observer=observer,

--- a/python/pyglobalsearch.pyi
+++ b/python/pyglobalsearch.pyi
@@ -1603,7 +1603,7 @@ class observers:
 def optimize(
     problem: PyProblem,
     params: PyOQNLPParams,
-    local_solver: Optional[str] = "COBYLA",
+    local_solver: Optional[str] = None,
     local_solver_config: Optional[
         Union[
             PyLBFGS,
@@ -1645,9 +1645,11 @@ def optimize(
     With custom solver configuration::
 
         >>> cobyla_config = gs.builders.cobyla(max_iter=1000)
-        >>> result = gs.optimize(problem, params,
-        ...                     local_solver="COBYLA",
-        ...                     local_solver_config=cobyla_config)
+        >>> result = gs.optimize(problem, params, local_solver_config=cobyla_config)
+
+    Or using just the solver name for a default configuration::
+
+        >>> result = gs.optimize(problem, params, local_solver="LBFGS")
 
     With observer for progress monitoring::
 
@@ -1672,11 +1674,15 @@ def optimize(
     :type problem: PyProblem
     :param params: Parameters controlling the optimization algorithm behavior
     :type params: PyOQNLPParams
-    :param local_solver: Local optimization algorithm ("COBYLA", "LBFGS", "NewtonCG",
-                        "TrustRegion", "NelderMead", "SteepestDescent")
-    :type local_solver: str
-    :param local_solver_config: Custom configuration for the local solver (None for defaults)
-    :type local_solver_config: Union[PyLBFGS, PyNelderMead, PySteepestDescent, PyNewtonCG, PyTrustRegion, PyCOBYLA]
+    :param local_solver: Local optimization algorithm to use with its default configuration.
+                        One of: ``"COBYLA"`` (default when neither argument is given), ``"LBFGS"``,
+                        ``"NewtonCG"``, ``"TrustRegion"``, ``"NelderMead"``, ``"SteepestDescent"``.
+                        When passed alongside ``local_solver_config``, must match the config type.
+    :type local_solver: str, optional
+    :param local_solver_config: Custom configuration for the local solver. The solver type is inferred
+                               from the config object's type (e.g. ``PyCOBYLA``, ``PyLBFGS``).
+                               When passed alongside ``local_solver``, both must refer to the same solver type.
+    :type local_solver_config: Union[PyLBFGS, PyNelderMead, PySteepestDescent, PyNewtonCG, PyTrustRegion, PyCOBYLA], optional
     :param seed: Random seed for reproducible results (0 by default)
     :type seed: int
     :param target_objective: Stop optimization when this objective value is reached (None by default = no target)

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -813,19 +813,19 @@ fn optimize(
         // - Pass neither -> COBYLA with default config.
         // - Pass both -> allowed only when they agree, errors on mismatch.
         let local_solver_config = if let Some(config) = local_solver_config {
-            let (built_config, inferred_name) =
+            let (built_config, inferred_type) =
                 if let Ok(c) = config.extract::<crate::builders::PyCOBYLA>(py) {
-                    (c.to_builder().build(), "cobyla")
+                    (c.to_builder().build(), LocalSolverType::COBYLA)
                 } else if let Ok(c) = config.extract::<crate::builders::PyLBFGS>(py) {
-                    (c.to_builder().build(), "lbfgs")
+                    (c.to_builder().build(), LocalSolverType::LBFGS)
                 } else if let Ok(c) = config.extract::<crate::builders::PyNelderMead>(py) {
-                    (c.to_builder().build(), "nelder-mead")
+                    (c.to_builder().build(), LocalSolverType::NelderMead)
                 } else if let Ok(c) = config.extract::<crate::builders::PySteepestDescent>(py) {
-                    (c.to_builder().build(), "steepestdescent")
+                    (c.to_builder().build(), LocalSolverType::SteepestDescent)
                 } else if let Ok(c) = config.extract::<crate::builders::PyNewtonCG>(py) {
-                    (c.to_builder().build(), "newtoncg")
+                    (c.to_builder().build(), LocalSolverType::NewtonCG)
                 } else if let Ok(c) = config.extract::<crate::builders::PyTrustRegion>(py) {
-                    (c.to_builder().build(), "trustregion")
+                    (c.to_builder().build(), LocalSolverType::TrustRegion)
                 } else {
                     return Err(PyValueError::new_err(
                         "local_solver_config must be one of: PyCOBYLA, PyLBFGS, PyNelderMead, \
@@ -838,12 +838,11 @@ fn optimize(
             if let Some(name) = local_solver {
                 let expected = LocalSolverType::from_string(name)
                     .map_err(|e| PyValueError::new_err(e.to_string()))?;
-                let inferred = LocalSolverType::from_string(inferred_name).unwrap();
-                if expected != inferred {
+                if expected != inferred_type {
                     return Err(PyValueError::new_err(format!(
-                        "local_solver \"{}\" does not match local_solver_config type \"{}\". \
+                        "local_solver \"{name}\" does not match local_solver_config type \
+                         \"{inferred_type:?}\". \
                          Remove local_solver or make sure both refer to the same solver.",
-                        name, inferred_name,
                     )));
                 }
             }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -711,10 +711,14 @@ impl Problem for PyProblem {
 /// :type params: PyOQNLPParams
 /// :param observer: Optional observer for tracking algorithm progress and metrics
 /// :type observer: PyObserver, optional
-/// :param local_solver: Local optimization algorithm ("COBYLA", "LBFGS", "NewtonCG", "TrustRegion", "NelderMead", "SteepestDescent")
+/// :param local_solver: Local optimization algorithm to use with its default configuration.
+///     One of: ``"COBYLA"`` (default), ``"LBFGS"``, ``"NewtonCG"``, ``"TrustRegion"``, ``"NelderMead"``, ``"SteepestDescent"``.
+///     When passed alongside ``local_solver_config``, must match the config type or a ``ValueError`` is raised.
 /// :type local_solver: str, optional
-/// :param local_solver_config: Custom configuration for the local solver (must match solver type)
-/// :type local_solver_config: object, optional
+/// :param local_solver_config: Custom configuration for the local solver. The solver type is inferred
+///     directly from the config object's type (e.g. ``PyCOBYLA``, ``PyLBFGS``).
+///     When passed alongside ``local_solver``, both must refer to the same solver type.
+/// :type local_solver_config: PyCOBYLA | PyLBFGS | PyNelderMead | PySteepestDescent | PyNewtonCG | PyTrustRegion, optional
 /// :param seed: Random seed for reproducible results
 /// :type seed: int, optional
 /// :param target_objective: Stop optimization when this objective value is reached
@@ -748,9 +752,11 @@ impl Problem for PyProblem {
 /// With custom solver configuration:
 ///
 /// >>> cobyla_config = gs.builders.cobyla(max_iter=1000)
-/// >>> result = gs.optimize(problem, params,
-/// ...                     local_solver="COBYLA",
-/// ...                     local_solver_config=cobyla_config)
+/// >>> result = gs.optimize(problem, params, local_solver_config=cobyla_config)
+///
+/// Or using just the solver name for a default configuration:
+///
+/// >>> result = gs.optimize(problem, params, local_solver="LBFGS")
 ///
 /// With early stopping:
 ///
@@ -799,86 +805,61 @@ fn optimize(
     with_points: Option<Vec<Vec<f64>>>,
 ) -> PyResult<PySolutionSet> {
     Python::attach(|py| {
-        // Convert local_solver string to enum
-        let solver_type = LocalSolverType::from_string(local_solver.unwrap_or("cobyla"))
-            .map_err(|e| PyValueError::new_err(e.to_string()))?;
-
         let seed = seed.unwrap_or(0);
 
-        // Create local solver configuration (default)
+        // Build the local solver config:
+        // - Pass only local_solver_config -> solver type inferred from the config object.
+        // - Pass only local_solver (string) -> use that solver with its default config.
+        // - Pass neither -> COBYLA with default config.
+        // - Pass both -> allowed only when they agree, errors on mismatch.
         let local_solver_config = if let Some(config) = local_solver_config {
-            match solver_type {
-                LocalSolverType::LBFGS => {
-                    if let Ok(lbfgs_config) = config.extract::<crate::builders::PyLBFGS>(py) {
-                        lbfgs_config.to_builder().build()
-                    } else {
-                        return Err(PyValueError::new_err(
-                            "Expected PyLBFGS for LBFGS solver type".to_string(),
-                        ));
-                    }
-                }
-                LocalSolverType::NelderMead => {
-                    if let Ok(neldermead_config) =
-                        config.extract::<crate::builders::PyNelderMead>(py)
-                    {
-                        neldermead_config.to_builder().build()
-                    } else {
-                        return Err(PyValueError::new_err(
-                            "Expected PyNelderMead for NelderMead solver type".to_string(),
-                        ));
-                    }
-                }
-                LocalSolverType::SteepestDescent => {
-                    if let Ok(steepest_descent_config) =
-                        config.extract::<crate::builders::PySteepestDescent>(py)
-                    {
-                        steepest_descent_config.to_builder().build()
-                    } else {
-                        return Err(PyValueError::new_err(
-                            "Expected PySteepestDescent for SteepestDescent solver type"
-                                .to_string(),
-                        ));
-                    }
-                }
-                LocalSolverType::NewtonCG => {
-                    if let Ok(newtoncg_config) = config.extract::<crate::builders::PyNewtonCG>(py) {
-                        newtoncg_config.to_builder().build()
-                    } else {
-                        return Err(PyValueError::new_err(
-                            "Expected PyNewtonCG for NewtonCG solver type".to_string(),
-                        ));
-                    }
-                }
-                LocalSolverType::TrustRegion => {
-                    if let Ok(trustregion_config) =
-                        config.extract::<crate::builders::PyTrustRegion>(py)
-                    {
-                        trustregion_config.to_builder().build()
-                    } else {
-                        return Err(PyValueError::new_err(
-                            "Expected PyTrustRegion for TrustRegion solver type".to_string(),
-                        ));
-                    }
-                }
-                LocalSolverType::COBYLA => {
-                    if let Ok(cobyla_config) = config.extract::<crate::builders::PyCOBYLA>(py) {
-                        cobyla_config.to_builder().build()
-                    } else {
-                        return Err(PyValueError::new_err(
-                            "Expected PyCOBYLA for COBYLA solver type".to_string(),
-                        ));
-                    }
+            let (built_config, inferred_name) =
+                if let Ok(c) = config.extract::<crate::builders::PyCOBYLA>(py) {
+                    (c.to_builder().build(), "cobyla")
+                } else if let Ok(c) = config.extract::<crate::builders::PyLBFGS>(py) {
+                    (c.to_builder().build(), "lbfgs")
+                } else if let Ok(c) = config.extract::<crate::builders::PyNelderMead>(py) {
+                    (c.to_builder().build(), "nelder-mead")
+                } else if let Ok(c) = config.extract::<crate::builders::PySteepestDescent>(py) {
+                    (c.to_builder().build(), "steepestdescent")
+                } else if let Ok(c) = config.extract::<crate::builders::PyNewtonCG>(py) {
+                    (c.to_builder().build(), "newtoncg")
+                } else if let Ok(c) = config.extract::<crate::builders::PyTrustRegion>(py) {
+                    (c.to_builder().build(), "trustregion")
+                } else {
+                    return Err(PyValueError::new_err(
+                        "local_solver_config must be one of: PyCOBYLA, PyLBFGS, PyNelderMead, \
+                         PySteepestDescent, PyNewtonCG, PyTrustRegion"
+                            .to_string(),
+                    ));
+                };
+
+            // If a solver name was also supplied, verify it agrees with the config type.
+            if let Some(name) = local_solver {
+                let expected = LocalSolverType::from_string(name)
+                    .map_err(|e| PyValueError::new_err(e.to_string()))?;
+                let inferred = LocalSolverType::from_string(inferred_name).unwrap();
+                if expected != inferred {
+                    return Err(PyValueError::new_err(format!(
+                        "local_solver \"{}\" does not match local_solver_config type \"{}\". \
+                         Remove local_solver or make sure both refer to the same solver.",
+                        name, inferred_name,
+                    )));
                 }
             }
+
+            built_config
         } else {
-            // Create default local solver configuration
+            // No config provided - use the solver string to pick a default
+            let solver_type = LocalSolverType::from_string(local_solver.unwrap_or("cobyla"))
+                .map_err(|e| PyValueError::new_err(e.to_string()))?;
             match solver_type {
+                LocalSolverType::COBYLA => COBYLABuilder::default().build(),
                 LocalSolverType::LBFGS => LBFGSBuilder::default().build(),
-                LocalSolverType::NewtonCG => NewtonCGBuilder::default().build(),
-                LocalSolverType::TrustRegion => TrustRegionBuilder::default().build(),
                 LocalSolverType::NelderMead => NelderMeadBuilder::default().build(),
                 LocalSolverType::SteepestDescent => SteepestDescentBuilder::default().build(),
-                LocalSolverType::COBYLA => COBYLABuilder::default().build(),
+                LocalSolverType::NewtonCG => NewtonCGBuilder::default().build(),
+                LocalSolverType::TrustRegion => TrustRegionBuilder::default().build(),
             }
         };
 
@@ -889,7 +870,6 @@ fn optimize(
             threshold_factor: params.threshold_factor,
             distance_factor: params.distance_factor,
             seed,
-            local_solver_type: solver_type,
             local_solver_config,
         };
 

--- a/python/tests/test_error_handling.py
+++ b/python/tests/test_error_handling.py
@@ -115,7 +115,7 @@ def test_local_solver_config_type_mismatch():
     except ValueError as e:
         assert "does not match" in str(e)
         assert "LBFGS" in str(e)
-        assert "cobyla" in str(e)
+        assert "COBYLA" in str(e)
 
 
 def test_local_solver_config_matching_name_is_allowed():

--- a/python/tests/test_error_handling.py
+++ b/python/tests/test_error_handling.py
@@ -102,3 +102,26 @@ def test_trustregion_requires_hessian():
             str(e)
             == "OQNLP Error: Local solver failed: Local Solver Error: unknown failed to run: Hessian not implemented and needed for local solver"
         )
+
+
+def test_local_solver_config_type_mismatch():
+    """Test that specifying local_solver and local_solver_config with mismatched types raises ValueError."""
+    cobyla_config = gs.builders.PyCOBYLA()
+    try:
+        gs.optimize(
+            problem, params, local_solver="LBFGS", local_solver_config=cobyla_config
+        )
+        assert False, "Expected ValueError for solver/config type mismatch"
+    except ValueError as e:
+        assert "does not match" in str(e)
+        assert "LBFGS" in str(e)
+        assert "cobyla" in str(e)
+
+
+def test_local_solver_config_matching_name_is_allowed():
+    """Test that specifying both local_solver and local_solver_config with matching types is allowed."""
+    cobyla_config = gs.builders.PyCOBYLA()
+    result = gs.optimize(
+        problem, params, local_solver="COBYLA", local_solver_config=cobyla_config
+    )
+    assert result is not None

--- a/src/local_solver/builders.rs
+++ b/src/local_solver/builders.rs
@@ -348,6 +348,25 @@ impl LocalSolverConfig {
     pub fn cobyla() -> COBYLABuilder {
         COBYLABuilder::default()
     }
+
+    /// Returns the corresponding LocalSolverType for this configuration
+    pub fn solver_type(&self) -> crate::types::LocalSolverType {
+        match self {
+            #[cfg(feature = "argmin")]
+            LocalSolverConfig::LBFGS { .. } => crate::types::LocalSolverType::LBFGS,
+            #[cfg(feature = "argmin")]
+            LocalSolverConfig::NelderMead { .. } => crate::types::LocalSolverType::NelderMead,
+            #[cfg(feature = "argmin")]
+            LocalSolverConfig::SteepestDescent { .. } => {
+                crate::types::LocalSolverType::SteepestDescent
+            }
+            #[cfg(feature = "argmin")]
+            LocalSolverConfig::TrustRegion { .. } => crate::types::LocalSolverType::TrustRegion,
+            #[cfg(feature = "argmin")]
+            LocalSolverConfig::NewtonCG { .. } => crate::types::LocalSolverType::NewtonCG,
+            LocalSolverConfig::COBYLA { .. } => crate::types::LocalSolverType::COBYLA,
+        }
+    }
 }
 
 #[cfg(feature = "argmin")]

--- a/src/local_solver/builders.rs
+++ b/src/local_solver/builders.rs
@@ -2263,4 +2263,33 @@ mod tests_builders {
             _ => panic!("Expected COBYLA local solver"),
         }
     }
+
+    #[test]
+    /// Test that `LocalSolverConfig::solver_type()` returns the correct `LocalSolverType`
+    /// for the COBYLA variant
+    fn test_solver_type_cobyla() {
+        use crate::types::LocalSolverType;
+        let config = COBYLABuilder::default().build();
+        assert_eq!(config.solver_type(), LocalSolverType::COBYLA);
+    }
+
+    #[cfg(feature = "argmin")]
+    #[test]
+    /// Test that `LocalSolverConfig::solver_type()` returns the correct `LocalSolverType`
+    /// for all argmin variants
+    fn test_solver_type_argmin_variants() {
+        use crate::types::LocalSolverType;
+
+        assert_eq!(LBFGSBuilder::default().build().solver_type(), LocalSolverType::LBFGS);
+        assert_eq!(NelderMeadBuilder::default().build().solver_type(), LocalSolverType::NelderMead);
+        assert_eq!(
+            SteepestDescentBuilder::default().build().solver_type(),
+            LocalSolverType::SteepestDescent
+        );
+        assert_eq!(
+            TrustRegionBuilder::default().build().solver_type(),
+            LocalSolverType::TrustRegion
+        );
+        assert_eq!(NewtonCGBuilder::default().build().solver_type(), LocalSolverType::NewtonCG);
+    }
 }

--- a/src/local_solver/mod.rs
+++ b/src/local_solver/mod.rs
@@ -49,7 +49,7 @@
 //! use globalsearch::local_solver::builders::{
 //!     LBFGSBuilder, HagerZhangBuilder, TrustRegionBuilder, TrustRegionRadiusMethod
 //! };
-//! use globalsearch::types::{LocalSolverType, OQNLPParams};
+//! use globalsearch::types::OQNLPParams;
 //!
 //! // L-BFGS with custom line search
 //! let lbfgs_config = LBFGSBuilder::default()
@@ -70,7 +70,6 @@
 //!
 //! // Use in OQNLP parameters
 //! let params = OQNLPParams {
-//!     local_solver_type: LocalSolverType::LBFGS,
 //!     local_solver_config: lbfgs_config,
 //!     ..OQNLPParams::default()
 //! };

--- a/src/observers/mod.rs
+++ b/src/observers/mod.rs
@@ -1418,7 +1418,7 @@ mod tests_observers {
         use crate::local_solver::builders::COBYLABuilder;
         use crate::oqnlp::OQNLP;
         use crate::problem::Problem;
-        use crate::types::{EvaluationError, LocalSolverType, OQNLPParams};
+        use crate::types::{EvaluationError, OQNLPParams};
         use ndarray::{Array1, Array2};
 
         /// Simple quadratic problem: sum x_i^2 for i=1 to n
@@ -1460,7 +1460,6 @@ mod tests_observers {
             threshold_factor: 0.5,
             distance_factor: 0.5,
             population_size: 150,
-            local_solver_type: LocalSolverType::COBYLA,
             local_solver_config: COBYLABuilder::default().max_iter(25).build(),
             seed: 0,
         };

--- a/src/oqnlp.rs
+++ b/src/oqnlp.rs
@@ -61,7 +61,7 @@
 //! use globalsearch::problem::Problem;
 //! use globalsearch::{
 //!     oqnlp::OQNLP,
-//!     types::{EvaluationError, LocalSolverType, OQNLPParams, SolutionSet},
+//!     types::{EvaluationError, OQNLPParams, SolutionSet},
 //! };
 //! use ndarray::{array, Array1, Array2};
 //!
@@ -109,7 +109,6 @@
 //!     // It is recommended that you adjust these parameters to your problem
 //!     // and the desired behavior of the algorithm, instead of using the default values.
 //!     let params: OQNLPParams = OQNLPParams {
-//!         local_solver_type: LocalSolverType::TrustRegion,
 //!         local_solver_config: TrustRegionBuilder::default()
 //!             .method(TrustRegionRadiusMethod::Steihaug)
 //!             .build(),
@@ -467,7 +466,7 @@ impl<P: Problem + Clone + Send + Sync> OQNLP<P> {
             distance_filter: DistanceFilter::new(filter_params)?,
             local_solver: LocalSolver::new(
                 problem,
-                params.local_solver_type.clone(),
+                params.local_solver_type(),
                 params.local_solver_config.clone(),
             ),
             solution_set: None,
@@ -1886,7 +1885,7 @@ impl<P: Problem + Clone + Send + Sync> OQNLP<P> {
             if local_candidates.len() >= 2 && self.enable_parallel {
                 // Clone once for sharing across threads
                 let problem = self.problem.clone();
-                let solver_type = self.params.local_solver_type.clone();
+                let solver_type = self.params.local_solver_type();
                 let solver_config = self.params.local_solver_config.clone();
                 let track_evals =
                     self.observer.as_ref().map(|obs| obs.should_observe_stage2()).unwrap_or(false);

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,17 +15,19 @@
 //! ## Example
 //!
 //! ```rust
-//! use globalsearch::types::{OQNLPParams, LocalSolverType};
+//! use globalsearch::types::OQNLPParams;
 //! use globalsearch::local_solver::builders::COBYLABuilder;
 //!
 //! // Create optimization parameters
 //! let params = OQNLPParams {
 //!     iterations: 500,
 //!     population_size: 1000,
-//!     local_solver_type: LocalSolverType::COBYLA,
 //!     local_solver_config: COBYLABuilder::default().build(),
 //!     ..OQNLPParams::default()
 //! };
+//!
+//! // The local solver type is automatically inferred from the config
+//! println!("Using solver: {:?}", params.local_solver_type());
 //! ```
 
 use crate::local_solver::builders::{COBYLABuilder, LocalSolverConfig};
@@ -86,14 +88,18 @@ pub struct OQNLPParams {
     /// Factor that influences the minimum required distance between candidate solutions
     pub distance_factor: f64,
 
-    /// Type of local solver to use from argmin
-    pub local_solver_type: LocalSolverType,
-
     /// Configuration for the local solver
     pub local_solver_config: LocalSolverConfig,
 
     /// Random seed for the algorithm
     pub seed: u64,
+}
+
+impl OQNLPParams {
+    /// Returns the local solver type inferred from the local_solver_config
+    pub fn local_solver_type(&self) -> LocalSolverType {
+        self.local_solver_config.solver_type()
+    }
 }
 
 impl Default for OQNLPParams {
@@ -107,8 +113,7 @@ impl Default for OQNLPParams {
     /// - `wait_cycle`: 15
     /// - `threshold_factor`: 0.2
     /// - `distance_factor`: 0.75
-    /// - `local_solver_type`: `LocalSolverType::COBYLA`
-    /// - `local_solver_config`: `COBYLABuilder::default().build()`
+    /// - `local_solver_config`: `COBYLABuilder::default().build()` (COBYLA)
     /// - `seed`: 0
     fn default() -> Self {
         Self {
@@ -117,7 +122,6 @@ impl Default for OQNLPParams {
             wait_cycle: 15,
             threshold_factor: 0.2,
             distance_factor: 0.75,
-            local_solver_type: LocalSolverType::COBYLA,
             local_solver_config: COBYLABuilder::default().build(),
             seed: 0,
         }
@@ -758,7 +762,7 @@ impl fmt::Display for OQNLPCheckpoint {
         writeln!(f, "  Wait cycle: {}", self.params.wait_cycle)?;
         writeln!(f, "  Threshold factor: {}", self.params.threshold_factor)?;
         writeln!(f, "  Distance factor: {}", self.params.distance_factor)?;
-        writeln!(f, "  Local solver: {:?}", self.params.local_solver_type)?;
+        writeln!(f, "  Local solver: {:?}", self.params.local_solver_type())?;
         writeln!(f, "  Seed: {}", self.params.seed)?;
 
         if let Some(target) = self.target_objective {
@@ -923,7 +927,6 @@ mod tests_types {
                 threshold_factor: 0.3,
                 distance_factor: 0.8,
                 seed: 42,
-                local_solver_type: LocalSolverType::COBYLA,
                 local_solver_config: crate::local_solver::builders::COBYLABuilder::default()
                     .build(),
             },

--- a/src/types.rs
+++ b/src/types.rs
@@ -870,6 +870,49 @@ mod tests_types {
         let _should_panic: LocalSolution = solution_set[0].clone();
     }
 
+    #[test]
+    /// Test that `OQNLPParams::local_solver_type()` correctly infers the solver type
+    /// from the `local_solver_config` field for the COBYLA default
+    fn test_oqnlp_params_local_solver_type_default() {
+        let params = OQNLPParams::default();
+        assert_eq!(params.local_solver_type(), LocalSolverType::COBYLA);
+    }
+
+    #[cfg(feature = "argmin")]
+    #[test]
+    /// Test that `OQNLPParams::local_solver_type()` correctly infers the solver type
+    /// for each argmin config variant
+    fn test_oqnlp_params_local_solver_type_argmin_variants() {
+        use crate::local_solver::builders::{
+            LBFGSBuilder, NelderMeadBuilder, NewtonCGBuilder, SteepestDescentBuilder,
+            TrustRegionBuilder,
+        };
+
+        let cases: &[(LocalSolverType, crate::local_solver::builders::LocalSolverConfig)] = &[
+            (LocalSolverType::LBFGS, LBFGSBuilder::default().build()),
+            (LocalSolverType::NelderMead, NelderMeadBuilder::default().build()),
+            (LocalSolverType::SteepestDescent, SteepestDescentBuilder::default().build()),
+            (LocalSolverType::TrustRegion, TrustRegionBuilder::default().build()),
+            (LocalSolverType::NewtonCG, NewtonCGBuilder::default().build()),
+        ];
+
+        for (expected_type, config) in cases {
+            let params =
+                OQNLPParams { local_solver_config: config.clone(), ..OQNLPParams::default() };
+            assert_eq!(&params.local_solver_type(), expected_type);
+        }
+    }
+
+    #[test]
+    /// Test that setting `local_solver_config` directly determines the inferred type,
+    /// making it impossible to create a mismatch between config and type
+    fn test_oqnlp_params_solver_type_matches_config() {
+        use crate::local_solver::builders::COBYLABuilder;
+        let config = COBYLABuilder::default().max_iter(500).build();
+        let params = OQNLPParams { local_solver_config: config, ..OQNLPParams::default() };
+        assert_eq!(params.local_solver_type(), LocalSolverType::COBYLA);
+    }
+
     #[cfg(feature = "argmin")]
     #[test]
     /// Test the from_string method for the LocalSolverType enum


### PR DESCRIPTION
## 📝 Description

Remove the explicit `local_solver_type`  field from `OQNLPParams` and derive the solver type from the `local_solver_config` field. 
Added `LocalSolverConfig::solver_type` and `OQNLPParams::local_solver_type`. 

This simplifies the API by avoiding duplicate specification of the solver type and ensures that the solver type is inferred from its configuration.
This also avoids keeping two fields in sync, which could be set inconsistently.

Updated Python bindings examples, benches, observers and README.

## 📋 Checklist

- [ ] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All tests pass (`cargo test`)