### PR TITLE
feat!: replace cobyla with basin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "basin"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fffea1dff2227a73e150b3defee598fba70e025505d819d4ee7dd22cbaf436e"
+dependencies = [
+ "num-traits",
+ "rand 0.10.0",
+ "rand_chacha 0.10.0",
+ "rand_distr",
+ "web-time",
+]
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,12 +224,6 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
-
-[[package]]
-name = "cobyla"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7c3233e5d400a8fd61b50b79797d28a0657e4c0abeb41469b69d2d9d60ef3e"
 
 [[package]]
 name = "core-foundation-sys"
@@ -355,9 +362,9 @@ version = "0.6.0"
 dependencies = [
  "argmin",
  "argmin-math",
+ "basin",
  "bincode",
  "chrono",
- "cobyla",
  "criterion",
  "kdam",
  "ndarray",
@@ -488,6 +495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -668,7 +682,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.0",
 ]
 
@@ -694,6 +708,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +732,16 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.0",
+]
 
 [[package]]
 name = "rand_xoshiro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/GermanHeim/globalsearch-rs"
 keywords = ["optimization", "math", "science"]
 categories = ["science", "mathematics"]
 exclude = ["/media", ".github", "/python"]
-rust-version = "1.85"                                                                                      # MSRV
+rust-version = "1.87"                                                                                      # MSRV
 
 [dependencies]
 argmin = { version = "0.11.0", optional = true }
@@ -23,7 +23,7 @@ kdam = { version = "0.6.4", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 bincode = { version = "2.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.42", features = ["serde"], optional = true }
-cobyla = "1.0.2"
+basin = { version = "1.11.0", default-features = false }
 
 [features]
 default = ["argmin"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 `globalsearch-rs`: Rust implementation of a modified version of the _OQNLP_ (_OptQuest/NLP_) algorithm with the core ideas from "Scatter Search and Local NLP Solvers: A Multistart Framework for Global Optimization" by Ugray et al. (2007). It combines scatter search metaheuristics with local minimization for global optimization of nonlinear problems.
 
-Similar to MATLAB's `GlobalSearch` \[2\], using cobyla, argmin, rayon and ndarray.
+Similar to MATLAB's `GlobalSearch` \[2\], using Basin, argmin, Rayon, and ndarray.
 
 ## Features
 
@@ -40,7 +40,7 @@ Similar to MATLAB's `GlobalSearch` \[2\], using cobyla, argmin, rayon and ndarra
 
 - 🎯 Multistart heuristic framework for global optimization
 
-- 📦 Local optimization using the cobyla \[3\] and argmin crate \[4\]
+- 📦 Local optimization using the Basin \[3\] and argmin \[4\] crates
 
 - 🚀 Parallel execution using Rayon
 
@@ -105,7 +105,7 @@ Similar to MATLAB's `GlobalSearch` \[2\], using cobyla, argmin, rayon and ndarra
    }
    ```
 
-   Depending on your choice of local solver, you might need to implement the `gradient` and `hessian` methods. Learn more about the local solver configuration in the [argmin docs](https://docs.rs/argmin/latest/argmin/solver/index.html) or the [`LocalSolverType`](https://docs.rs/globalsearch/latest/globalsearch/types/enum.LocalSolverType.html).
+   Depending on your choice of local solver, you might need to implement the `gradient` and `hessian` methods. Learn more about COBYLA in the [Basin docs](https://docs.rs/basin/latest/basin/struct.Cobyla.html), about the other solvers in the [argmin docs](https://docs.rs/argmin/latest/argmin/solver/index.html), or see [`LocalSolverType`](https://docs.rs/globalsearch/latest/globalsearch/types/enum.LocalSolverType.html).
 
    > 🔴 **Note:** If using a solver that isn't COBYLA, variable bounds are only used in the scatter search phase of the algorithm. The local solver is unconstrained (See [argmin issue #137](https://github.com/argmin-rs/argmin/issues/137)) and therefor can return solutions out of bounds. You can use OQNLP's `exclude_out_of_bounds` method to handle this if needed.
 
@@ -225,7 +225,7 @@ python/ # Python bindings
 ## Dependencies
 
 - [ndarray](https://github.com/rust-ndarray/ndarray)
-- [COBYLA](https://github.com/relf/cobyla)
+- [Basin](https://github.com/jolars/basin)
 - [argmin](https://github.com/argmin-rs/argmin) [feature: `argmin`]
 - [rayon](https://github.com/rayon-rs/rayon) [feature: `rayon`]
 - [kdam](https://github.com/clitic/kdam) [feature: `progress_bar`]
@@ -267,6 +267,6 @@ If `GlobalSearch-rs` has been significant in your research, and you would like t
 
 \[2\] GlobalSearch. The MathWorks, Inc. Available at: <https://www.mathworks.com/help/gads/globalsearch.html> (Accessed: 27 January 2025)
 
-\[3\] Rémi Lafage. cobyla - a pure Rust implementation. GitHub repository. MIT License. Available at: <https://github.com/relf/cobyla> (Accessed: 17 September 2025)
+\[3\] Johan Larsson. Basin—numerical optimization in pure Rust. Available at: <https://basin.rs> (Accessed: 7 September 2026)
 
 \[4\] Kroboth, S. argmin{}. Available at: <https://argmin-rs.org/> (Accessed: 25 January 2025)

--- a/examples/basic_tutorial.rs
+++ b/examples/basic_tutorial.rs
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Step 2: Configure local optimization parameters
     let local_solver_config = COBYLABuilder::default()
-        .max_iter(500) // Maximum iterations for COBYLA
+        .max_iter(500) // Maximum objective evaluations for COBYLA
         .initial_step_size(0.1) // Initial step size for COBYLA
         .ftol_rel(1e-10) // Relative tolerance
         .ftol_abs(1e-12) // Absolute tolerance

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -47,6 +47,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "basin"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fffea1dff2227a73e150b3defee598fba70e025505d819d4ee7dd22cbaf436e"
+dependencies = [
+ "num-traits",
+ "rand 0.10.0",
+ "rand_chacha 0.10.0",
+ "rand_distr",
+ "web-time",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,12 +87,6 @@ dependencies = [
  "cpufeatures",
  "rand_core 0.10.0",
 ]
-
-[[package]]
-name = "cobyla"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7c3233e5d400a8fd61b50b79797d28a0657e4c0abeb41469b69d2d9d60ef3e"
 
 [[package]]
 name = "cpufeatures"
@@ -165,7 +172,7 @@ version = "0.6.0"
 dependencies = [
  "argmin",
  "argmin-math",
- "cobyla",
+ "basin",
  "ndarray",
  "rand 0.10.0",
  "rayon",
@@ -240,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -469,7 +483,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -495,6 +509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +532,16 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.0",
+]
 
 [[package]]
 name = "rand_xoshiro"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/GermanHeim/globalsearch-rs"
 keywords = ["optimization", "math", "science"]
 categories = ["science", "mathematics"]
 publish = false
-rust-version = "1.85"
+rust-version = "1.87"
 exclude = ["/media"]
 
 [lib]

--- a/python/pyglobalsearch.pyi
+++ b/python/pyglobalsearch.pyi
@@ -829,9 +829,9 @@ class PyCOBYLA:
     """
     Configuration for the COBYLA (Constrained Optimization BY Linear Approximations) solver.
 
-    COBYLA is a derivative-free optimization algorithm that can handle inequality constraints.
-    It's particularly useful when gradients are not available or when dealing with noisy
-    objective functions.
+    This configuration uses Basin's derivative-free COBYLA implementation. It is particularly
+    useful when gradients are unavailable or when dealing with noisy objective functions and
+    inequality constraints.
 
     Examples
     --------
@@ -854,7 +854,7 @@ class PyCOBYLA:
     **Attributes**
 
     max_iter
-        Maximum number of iterations
+        Maximum number of objective evaluations
     step_size
         Initial step size for the algorithm
     ftol_rel
@@ -1171,7 +1171,7 @@ class builders:
         --------
             >>> cobyla_config = gs.builders.cobyla(max_iter=500, step_size=0.5)
 
-        :param max_iter: Maximum number of iterations (default 300)
+        :param max_iter: Maximum number of objective evaluations (default 300)
         :type max_iter: int
         :param step_size: Initial step size (default 1.0)
         :type step_size: float

--- a/python/src/builders.rs
+++ b/python/src/builders.rs
@@ -833,12 +833,12 @@ fn trustregion(
 #[derive(Debug, Clone)]
 /// COBYLA (Constrained Optimization BY Linear Approximations) solver configuration.
 ///
-/// COBYLA is a derivative-free optimization algorithm that can handle inequality
-/// constraints. It works by building linear approximations to the objective function
+/// This configuration uses Basin's derivative-free COBYLA implementation, which can
+/// handle inequality constraints. It builds linear approximations to the objective function
 /// and constraints, making it suitable for problems where gradients are unavailable
 /// or unreliable.
 ///
-/// :param max_iter: Maximum number of iterations
+/// :param max_iter: Maximum number of objective evaluations
 /// :type max_iter: int
 /// :param step_size: Initial trust region radius
 /// :type step_size: float
@@ -862,9 +862,9 @@ fn trustregion(
 ///
 /// COBYLA stops when any of these conditions are met:
 ///
-/// - Maximum iterations reached
-/// - Function tolerance satisfied: \|f_new - f_old\| < ftol_abs + ftol_rel * \|f_old\|
-/// - Parameter tolerance satisfied: \|x_new - x_old\| < xtol_abs + xtol_rel * \|x_old\|
+/// - Maximum objective evaluations reached
+/// - Function tolerance satisfied
+/// - The trust-region radius reaches the resolution derived from the parameter tolerances
 ///
 /// Examples
 /// --------
@@ -876,25 +876,19 @@ fn trustregion(
 ///
 /// >>> precise = gs.builders.cobyla(
 /// ...     max_iter=1000,
-/// ...     xtol_abs=[1e-10] * n_vars  # Very tight parameter tolerance
+/// ...     xtol_abs=[1e-10] * n_vars,  # Very tight parameter tolerance.
 /// ... )
 ///
 /// For expensive function evaluations:
 ///
 /// >>> efficient = gs.builders.cobyla(
 /// ...     max_iter=100,
-/// ...     ftol_rel=1e-4,  # Looser function tolerance
-/// ...     step_size=0.1   # Smaller initial steps
-/// ... )
-///
-/// Different tolerance per variable (for scaled problems):
-///
-/// >>> scaled = gs.builders.cobyla(
-/// ...     xtol_abs=[1e-6, 1e-8, 1e-4]  # x1: 1e-6, x2: 1e-8, x3: 1e-4
+/// ...     ftol_rel=1e-4,  # Looser function tolerance.
+/// ...     step_size=0.1,  # Smaller initial steps.
 /// ... )
 pub struct PyCOBYLA {
     #[pyo3(get, set)]
-    /// Maximum number of iterations
+    /// Maximum number of objective evaluations
     ///
     /// :type: int
     pub max_iter: u64,
@@ -924,9 +918,9 @@ pub struct PyCOBYLA {
     pub xtol_rel: Option<f64>,
 
     #[pyo3(get, set)]
-    /// Absolute tolerance for parameter convergence
+    /// Per-variable absolute tolerances for parameter convergence
     ///
-    /// :type: float, optional
+    /// :type: list[float], optional
     pub xtol_abs: Option<Vec<f64>>,
 }
 
@@ -960,15 +954,12 @@ impl PyCOBYLA {
         if let Some(ftol_rel) = self.ftol_rel {
             builder = builder.ftol_rel(ftol_rel);
         }
-
         if let Some(ftol_abs) = self.ftol_abs {
             builder = builder.ftol_abs(ftol_abs);
         }
-
         if let Some(xtol_rel) = self.xtol_rel {
             builder = builder.xtol_rel(xtol_rel);
         }
-
         if let Some(xtol_abs) = &self.xtol_abs {
             builder = builder.xtol_abs(xtol_abs.clone());
         }
@@ -984,7 +975,7 @@ impl PyCOBYLA {
 /// solver in this library that can handle inequality constraints. It's also
 /// an excellent choice for derivative-free optimization.
 ///
-/// :param max_iter: Maximum number of optimization iterations
+/// :param max_iter: Maximum number of objective evaluations
 /// :type max_iter: int
 /// :param step_size: Initial trust region radius (larger = more exploration)
 /// :type step_size: float
@@ -1000,9 +991,9 @@ impl PyCOBYLA {
 /// :rtype: PyCOBYLA
 ///
 /// .. note::
-///    - If `xtol_abs` is provided, its length must match the problem dimension
+///    - If ``xtol_abs`` is provided, its length must match the problem dimension
 ///    - For constrained problems, COBYLA is currently the only supported solver
-///    - Larger `step_size` values encourage more exploration but may slow convergence
+///    - Larger ``step_size`` values encourage more exploration but may slow convergence.
 ///
 /// Examples
 /// --------
@@ -1015,13 +1006,7 @@ impl PyCOBYLA {
 /// >>> config = gs.builders.cobyla(
 /// ...     max_iter=1000,
 /// ...     step_size=0.1,
-/// ...     xtol_abs=[1e-8, 1e-8]  # Same tolerance for both variables
-/// ... )
-///
-/// Different tolerance per variable (useful for scaled problems):
-///
-/// >>> config = gs.builders.cobyla(
-/// ...     xtol_abs=[1e-6, 1e-8, 1e-4]  # x1: loose, x2: tight, x3: very loose
+/// ...     xtol_abs=[1e-8, 1e-8],  # Same tolerance for both variables.
 /// ... )
 #[pyo3(signature = (
     max_iter = 300,

--- a/src/local_solver/builders.rs
+++ b/src/local_solver/builders.rs
@@ -157,11 +157,11 @@ pub enum LocalSolverConfig {
         line_search_params: LineSearchParams,
     },
     COBYLA {
-        /// Maximum number of iterations for the COBYLA local solver
+        /// Maximum number of objective evaluations for the COBYLA local solver
         max_iter: u64,
         /// Initial step size for the algorithm
         ///
-        /// This determines the initial step size for the algorithm.
+        /// This determines the initial trust-region radius for the algorithm.
         /// Default is 0.5.
         initial_step_size: f64,
         /// Relative function tolerance
@@ -176,15 +176,14 @@ pub enum LocalSolverConfig {
         ftol_abs: f64,
         /// Relative parameter tolerance
         ///
-        /// Convergence criterion based on relative change in parameters.
+        /// Sets the final trust-region radius relative to `initial_step_size`.
         /// Default is 0 (disabled).
         xtol_rel: f64,
-        /// Absolute parameter tolerance
+        /// Per-variable absolute parameter tolerances
         ///
-        /// Convergence criterion based on absolute change in parameters.
         /// Each element corresponds to the absolute tolerance for that variable.
-        /// The algorithm stops when all x\[i\] change by less than xtol_abs\[i\].
-        /// Default is empty vector (disabled).
+        /// The largest positive tolerance contributes to the final trust-region radius.
+        /// Default is an empty vector (disabled).
         xtol_abs: Vec<f64>,
     },
 }
@@ -1034,8 +1033,8 @@ impl Default for NewtonCGBuilder {
 
 /// Configuration builder for COBYLA (Constrained Optimization BY Linear Approximations).
 ///
-/// COBYLA is a derivative-free optimization algorithm specifically designed for
-/// constrained optimization problems. It uses linear approximations of the
+/// This builder configures Basin's derivative-free COBYLA implementation for
+/// constrained optimization problems. COBYLA uses linear approximations of the
 /// objective function and constraints to guide the search.
 ///
 /// ## Algorithm Characteristics
@@ -1052,13 +1051,18 @@ impl Default for NewtonCGBuilder {
 /// - Problems with mixed discrete-continuous variables (after relaxation)
 ///
 /// ## Convergence Control
-/// - **Function tolerances**: `ftol_rel`, `ftol_abs` for objective convergence
-/// - **Parameter tolerances**: `xtol_rel`, `xtol_abs` for variable convergence
-/// - **Step size**: `initial_step_size` controls exploration scale
+/// - **Function tolerances**: `ftol_rel` and `ftol_abs` control objective convergence
+/// - **Parameter tolerances**: `xtol_rel` and `xtol_abs` control the final resolution
+/// - **Step size**: `initial_step_size` controls the initial exploration scale
+///
+/// The final trust-region radius is the maximum of `xtol_rel * initial_step_size`,
+/// the positive entries in `xtol_abs`, and a numerical floor of
+/// `max(sqrt(f64::EPSILON) * initial_step_size, f64::MIN_POSITIVE)`.
+/// This floor also applies when parameter tolerances are disabled.
 ///
 /// ## Performance Notes
 /// - Slower than gradient-based methods but more robust
-/// - Performance depends heavily on initial step size
+/// - Performance depends heavily on the initial trust-region radius
 /// - Best for small to medium-scale problems (< 50 variables)
 pub struct COBYLABuilder {
     max_iter: u64,
@@ -1082,11 +1086,11 @@ pub struct COBYLABuilder {
 /// // High-precision configuration for engineering optimization
 /// let config = COBYLABuilder::default()
 ///     .max_iter(1000)
-///     .initial_step_size(0.1)     // Match problem scaling
-///     .ftol_rel(1e-8)             // Tight relative tolerance
-///     .ftol_abs(1e-10)            // Tight absolute tolerance
-///     .xtol_rel(1e-6)             // Parameter convergence
-///     .xtol_abs(vec![1e-6, 1e-8]) // Per-variable absolute tolerances
+///     .initial_step_size(0.1)     // Match problem scaling.
+///     .ftol_rel(1e-8)             // Tight relative tolerance.
+///     .ftol_abs(1e-10)            // Tight absolute tolerance.
+///     .xtol_rel(1e-6)             // Request fine parameter resolution.
+///     .xtol_abs(vec![1e-6, 1e-8]) // Per-variable absolute tolerances.
 ///     .build();
 /// ```
 impl COBYLABuilder {
@@ -1109,12 +1113,12 @@ impl COBYLABuilder {
             initial_step_size: self.initial_step_size,
             ftol_rel: self.ftol_rel.unwrap_or(1e-6),
             ftol_abs: self.ftol_abs.unwrap_or(1e-8),
-            xtol_rel: self.xtol_rel.unwrap_or(0.0), // No default for x tolerances
-            xtol_abs: self.xtol_abs.unwrap_or_default(), // Empty vector means no tolerance
+            xtol_rel: self.xtol_rel.unwrap_or(0.0), // Zero disables relative parameter tolerance.
+            xtol_abs: self.xtol_abs.unwrap_or_default(), // An empty vector disables absolute tolerances.
         }
     }
 
-    /// Set the maximum number of iterations for the COBYLA local solver
+    /// Set the maximum number of objective evaluations for the COBYLA local solver
     pub fn max_iter(mut self, max_iter: u64) -> Self {
         self.max_iter = max_iter;
         self
@@ -1128,7 +1132,9 @@ impl COBYLABuilder {
 
     /// Set the relative function tolerance for the COBYLA local solver
     ///
-    /// The local solver stops when the objective function changes by less than `ftol_rel * |f(x)|`
+    /// At changes in the trust-region radius, the local solver stops when the objective
+    /// decreases by less than `ftol_rel * (|f_new| + |f_old|) / 2`.
+    /// Nonpositive values disable this convergence criterion.
     pub fn ftol_rel(mut self, ftol_rel: f64) -> Self {
         self.ftol_rel = Some(ftol_rel);
         self
@@ -1136,7 +1142,9 @@ impl COBYLABuilder {
 
     /// Set the absolute function tolerance for the COBYLA local solver
     ///
-    /// The local solver stops when the objective function changes by less than `ftol_abs`
+    /// At changes in the trust-region radius, the local solver stops when the objective
+    /// decreases by less than `ftol_abs`.
+    /// Nonpositive values disable this convergence criterion.
     pub fn ftol_abs(mut self, ftol_abs: f64) -> Self {
         self.ftol_abs = Some(ftol_abs);
         self
@@ -1144,18 +1152,20 @@ impl COBYLABuilder {
 
     /// Set the relative parameter tolerance for the COBYLA local solver
     ///
-    /// The local solver stops when all `x[i]` changes by less than `xtol_rel * x[i]`
+    /// Contributes `xtol_rel * initial_step_size` to the final trust-region radius.
+    /// The radius also accounts for absolute tolerances and a numerical floor.
+    /// Nonpositive values disable this relative tolerance.
     pub fn xtol_rel(mut self, xtol_rel: f64) -> Self {
         self.xtol_rel = Some(xtol_rel);
         self
     }
 
-    /// Set the absolute parameter tolerance for the COBYLA local solver
+    /// Set the per-variable absolute parameter tolerances for the COBYLA local solver
     ///
-    /// The local solver stops when all `x\[i\]` changes by less than `xtol_abs\[i\]`.
-    /// Each element in the vector corresponds to the tolerance for that variable.
-    /// If the vector is shorter than the number of variables, the last value is used
-    /// for remaining variables. An empty vector disables this convergence criterion.
+    /// Each element corresponds to the absolute tolerance for that variable.
+    /// A nonempty vector must contain one entry per variable. Its largest positive
+    /// entry contributes to the final trust-region radius, together with the relative
+    /// tolerance and a numerical floor. An empty vector disables absolute tolerances.
     pub fn xtol_abs(mut self, xtol_abs: Vec<f64>) -> Self {
         self.xtol_abs = Some(xtol_abs);
         self
@@ -1168,8 +1178,9 @@ impl COBYLABuilder {
 /// Default values:
 /// - `max_iter`: 300
 /// - `initial_step_size`: 0.5
-/// - Function tolerances: `ftol_abs = 1e-8`, `ftol_rel = 1e-6`
-/// - Parameter tolerances: disabled (empty vectors)
+/// - `ftol_rel`: 1e-6
+/// - `ftol_abs`: 1e-8
+/// - Parameter tolerances: disabled
 impl Default for COBYLABuilder {
     fn default() -> Self {
         COBYLABuilder {
@@ -2171,10 +2182,10 @@ mod tests_builders {
             } => {
                 assert_eq!(max_iter, 300);
                 assert_eq!(initial_step_size, 0.5);
-                assert_eq!(ftol_rel, 1e-6); // REL_TOL default
-                assert_eq!(ftol_abs, 1e-8); // ABS_TOL default
-                assert_eq!(xtol_rel, 0.0); // No default
-                assert_eq!(xtol_abs, Vec::<f64>::new()); // No default (empty vector)
+                assert_eq!(ftol_rel, 1e-6);
+                assert_eq!(ftol_abs, 1e-8);
+                assert_eq!(xtol_rel, 0.0);
+                assert!(xtol_abs.is_empty());
             }
             #[cfg_attr(not(feature = "argmin"), allow(unreachable_patterns))]
             _ => panic!("Expected COBYLA local solver"),
@@ -2184,8 +2195,15 @@ mod tests_builders {
     #[test]
     /// Test changing the parameters of COBYLA builder
     fn change_params_cobyla() {
-        let cobyla: LocalSolverConfig =
-            COBYLABuilder::default().max_iter(500).initial_step_size(0.1).ftol_rel(1e-10).build();
+        let xtol_abs = vec![1e-6, 1e-8];
+        let cobyla: LocalSolverConfig = COBYLABuilder::default()
+            .max_iter(500)
+            .initial_step_size(0.1)
+            .ftol_rel(1e-10)
+            .ftol_abs(1e-12)
+            .xtol_rel(1e-9)
+            .xtol_abs(xtol_abs.clone())
+            .build();
         match cobyla {
             LocalSolverConfig::COBYLA {
                 max_iter,
@@ -2193,14 +2211,14 @@ mod tests_builders {
                 ftol_rel,
                 ftol_abs,
                 xtol_rel,
-                xtol_abs,
+                xtol_abs: actual_xtol_abs,
             } => {
                 assert_eq!(max_iter, 500);
                 assert_eq!(initial_step_size, 0.1);
                 assert_eq!(ftol_rel, 1e-10);
-                assert_eq!(ftol_abs, 1e-8);
-                assert_eq!(xtol_rel, 0.0);
-                assert_eq!(xtol_abs, Vec::<f64>::new());
+                assert_eq!(ftol_abs, 1e-12);
+                assert_eq!(xtol_rel, 1e-9);
+                assert_eq!(actual_xtol_abs, xtol_abs);
             }
             #[cfg_attr(not(feature = "argmin"), allow(unreachable_patterns))]
             _ => panic!("Expected COBYLA local solver"),
@@ -2222,42 +2240,10 @@ mod tests_builders {
             } => {
                 assert_eq!(max_iter, 500);
                 assert_eq!(initial_step_size, 0.5);
-                assert_eq!(ftol_rel, 1e-6); // default
-                assert_eq!(ftol_abs, 1e-8); // default
-                assert_eq!(xtol_rel, 0.0); // default (no x tolerance)
-                assert_eq!(xtol_abs, Vec::<f64>::new()); // default (no x tolerance)
-            }
-            #[cfg_attr(not(feature = "argmin"), allow(unreachable_patterns))]
-            _ => panic!("Expected COBYLA local solver"),
-        }
-    }
-
-    #[test]
-    /// Test COBYLA builder with vector-based xtol_abs
-    fn test_cobyla_vector_xtol_abs() {
-        let xtol_vec = vec![1e-6, 1e-8, 1e-10];
-        let cobyla: LocalSolverConfig = COBYLABuilder::default()
-            .max_iter(1000)
-            .initial_step_size(0.1)
-            .ftol_rel(1e-8)
-            .xtol_abs(xtol_vec.clone())
-            .build();
-
-        match cobyla {
-            LocalSolverConfig::COBYLA {
-                max_iter,
-                initial_step_size,
-                ftol_rel,
-                ftol_abs,
-                xtol_rel,
-                xtol_abs,
-            } => {
-                assert_eq!(max_iter, 1000);
-                assert_eq!(initial_step_size, 0.1);
-                assert_eq!(ftol_rel, 1e-8);
-                assert_eq!(ftol_abs, 1e-8); // default
-                assert_eq!(xtol_rel, 0.0); // default
-                assert_eq!(xtol_abs, xtol_vec); // per-variable tolerances
+                assert_eq!(ftol_rel, 1e-6);
+                assert_eq!(ftol_abs, 1e-8);
+                assert_eq!(xtol_rel, 0.0);
+                assert!(xtol_abs.is_empty());
             }
             #[cfg_attr(not(feature = "argmin"), allow(unreachable_patterns))]
             _ => panic!("Expected COBYLA local solver"),

--- a/src/local_solver/mod.rs
+++ b/src/local_solver/mod.rs
@@ -1,7 +1,7 @@
 //! # Local Solver Module
 //!
 //! This module provides a comprehensive interface to classical optimization algorithms
-//! from the `cobyla` and `argmin` crates, adapted specifically for use within the OQNLP global
+//! from the `basin` and `argmin` crates, adapted specifically for use within the OQNLP global
 //! optimization framework.
 //!
 //! ## Module Structure
@@ -33,7 +33,7 @@
 //!   - Best for: Non-smooth, noisy problems
 //!   - Requires: Only objective function
 //!
-//! - **COBYLA**: Constrained Optimization BY Linear Approximation
+//! - **COBYLA**: Basin's Constrained Optimization BY Linear Approximation
 //!   - Best for: Constrained problems without derivatives
 //!   - Requires: Objective (optional constraints support)
 //!

--- a/src/local_solver/runner.rs
+++ b/src/local_solver/runner.rs
@@ -1,13 +1,13 @@
 //! # Local Solver Runner Module
 //!
 //! This module implements the execution engine for local optimization algorithms,
-//! providing a unified interface between the OQNLP framework and the `cobyla` and `argmin`
+//! providing a unified interface between the OQNLP framework and the `basin` and `argmin`
 //! crates.
 //!
 //! ## Architecture
 //!
 //! The runner acts as an adapter layer that:
-//! - Converts problem definitions to `cobyla` or`argmin`-compatible formats
+//! - Converts problem definitions to `basin` or `argmin`-compatible formats
 //! - Manages solver configuration and initialization
 //! - Handles execution and result extraction
 //! - Provides error handling and recovery mechanisms
@@ -66,8 +66,8 @@
 use crate::local_solver::builders::LocalSolverConfig;
 #[cfg(feature = "argmin")]
 use crate::local_solver::builders::{LineSearchMethod, TrustRegionRadiusMethod};
-use crate::problem::{Problem, evaluate_constraints};
-use crate::types::{LocalSolution, LocalSolverType};
+use crate::problem::Problem;
+use crate::types::{EvaluationError, LocalSolution, LocalSolverType};
 #[cfg(feature = "argmin")]
 use argmin::core::{CostFunction, Error, Executor, Gradient, Hessian};
 #[cfg(feature = "argmin")]
@@ -82,6 +82,7 @@ use argmin::solver::{
 use ndarray::Array1;
 #[cfg(feature = "argmin")]
 use ndarray::Array2;
+use std::{cell::Cell, rc::Rc};
 use thiserror::Error;
 
 // TODO: Do not repeat code in the linesearch branch, use helper function?
@@ -133,6 +134,152 @@ pub struct LocalSolver<P: Problem> {
     problem: P,
     local_solver_type: LocalSolverType,
     local_solver_config: LocalSolverConfig,
+}
+
+struct BasinProblem<'a, P: Problem> {
+    problem: &'a P,
+    lower_bounds: Vec<f64>,
+    upper_bounds: Vec<f64>,
+    problem_constraint_count: usize,
+    objective_evaluations: Rc<Cell<u64>>,
+    max_objective_evaluations: u64,
+}
+
+impl<P: Problem> BasinProblem<'_, P> {
+    /// Keep user callbacks inside their hard domain while Basin models bound
+    /// violations at the original trial point.
+    fn project_into_bounds(&self, param: &[f64]) -> Vec<f64> {
+        param
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                if *value < self.lower_bounds[index] {
+                    self.lower_bounds[index]
+                } else if *value > self.upper_bounds[index] {
+                    self.upper_bounds[index]
+                } else {
+                    *value
+                }
+            })
+            .collect()
+    }
+}
+
+impl<P: Problem> basin::CostFunction for BasinProblem<'_, P> {
+    type Param = Vec<f64>;
+    type Output = f64;
+    type Error = EvaluationError;
+
+    fn cost(&self, param: &Self::Param) -> Result<Self::Output, Self::Error> {
+        let evaluations = self.objective_evaluations.get();
+        if evaluations >= self.max_objective_evaluations {
+            // Basin can initialize or iterate over several points before its
+            // executor observes `MaxCostEvals`.
+            return Ok(f64::INFINITY);
+        }
+        self.objective_evaluations.set(evaluations + 1);
+
+        self.problem.objective(&Array1::from_vec(self.project_into_bounds(param)))
+    }
+}
+
+impl<P: Problem> basin::NonlinearInequalityConstraints for BasinProblem<'_, P> {
+    fn constraints(&self, param: &Self::Param) -> Result<Self::Param, Self::Error> {
+        let mut constraints = Vec::with_capacity(self.problem_constraint_count + 2 * param.len());
+        // Basin uses c(x) <= 0 and gives COBYLA no separate channel for box bounds.
+        let point = Array1::from_vec(self.project_into_bounds(param));
+        let problem_constraints = self.problem.constraints(&point)?;
+        let actual = problem_constraints.len();
+
+        if actual != self.problem_constraint_count {
+            return Err(EvaluationError::ConstraintDimensionMismatch {
+                expected: self.problem_constraint_count,
+                actual,
+            });
+        }
+        constraints.extend(problem_constraints.iter().map(|value| -*value));
+
+        for (index, value) in param.iter().enumerate() {
+            constraints.push(self.lower_bounds[index] - value);
+            constraints.push(value - self.upper_bounds[index]);
+        }
+
+        Ok(constraints)
+    }
+
+    fn num_constraints(&self) -> usize {
+        self.problem_constraint_count + 2 * self.lower_bounds.len()
+    }
+}
+
+/// Reproduce the former backend's cost check at trust-region reductions.
+///
+/// Basin's generic cost tolerances run after every executor iteration. COBYLA may
+/// keep the same incumbent while improving its interpolation geometry, so applying
+/// those criteria directly could stop a productive run prematurely.
+struct CobylaCostTolerance {
+    relative: f64,
+    absolute: f64,
+    last_rho: Option<f64>,
+    last_cost: Option<f64>,
+}
+
+impl CobylaCostTolerance {
+    fn new(relative: f64, absolute: f64) -> Self {
+        Self { relative, absolute, last_rho: None, last_cost: None }
+    }
+
+    fn check<S>(&mut self, state: &S) -> Option<basin::TerminationReason>
+    where
+        S: basin::State<Float = f64> + basin::RhoState,
+    {
+        let rho = state.rho();
+        let cost = state.cost();
+
+        let Some(last_rho) = self.last_rho.replace(rho) else {
+            self.last_cost = Some(cost);
+            return None;
+        };
+
+        if rho == last_rho {
+            return None;
+        }
+
+        let last_cost = self.last_cost.replace(cost)?;
+        if cost >= last_cost || !cost.is_finite() || !last_cost.is_finite() {
+            return None;
+        }
+
+        let difference = (cost - last_cost).abs();
+        let absolute_reached = self.absolute > 0.0 && difference < self.absolute;
+        let relative_reached = self.relative > 0.0
+            && difference < self.relative * 0.5 * (cost.abs() + last_cost.abs());
+
+        (absolute_reached || relative_reached).then_some(basin::TerminationReason::CostTolerance)
+    }
+}
+
+fn cobyla_rho_end(initial_step_size: f64, xtol_rel: f64, xtol_abs: &[f64]) -> f64 {
+    let relative_tolerance = if xtol_rel > 0.0 { xtol_rel * initial_step_size } else { 0.0 };
+    let absolute_tolerance =
+        xtol_abs.iter().copied().filter(|tolerance| *tolerance > 0.0).fold(0.0, f64::max);
+
+    // The former backend used zero when parameter tolerances were disabled. Basin
+    // requires a positive radius, so use the smallest scale-relative radius that
+    // remains numerically meaningful for its simplex geometry.
+    let numerical_floor = (f64::EPSILON.sqrt() * initial_step_size).max(f64::MIN_POSITIVE);
+    relative_tolerance.max(absolute_tolerance).max(numerical_floor)
+}
+
+fn ensure_cobyla_succeeded(reason: basin::TerminationReason) -> Result<(), LocalSolverError> {
+    if reason.is_failure() {
+        Err(LocalSolverError::RunFailed {
+            solver_type: "COBYLA".to_string(),
+            reason: format!("solver terminated with {reason:?}"),
+        })
+    } else {
+        Ok(())
+    }
 }
 
 impl<P: Problem> LocalSolver<P> {
@@ -955,18 +1102,13 @@ impl<P: Problem> LocalSolver<P> {
         }
     }
 
-    /// Solve the optimization problem using the COBYLA local solver
+    /// Solve the optimization problem using Basin's COBYLA local solver
     fn solve_cobyla(
         &self,
         initial_point: Array1<f64>,
         solver_config: &LocalSolverConfig,
         track_evaluations: bool,
     ) -> Result<(LocalSolution, u64), LocalSolverError> {
-        use std::sync::{
-            Arc, OnceLock,
-            atomic::{AtomicU64, Ordering},
-        };
-
         #[cfg_attr(not(feature = "argmin"), allow(irrefutable_let_patterns))]
         if let LocalSolverConfig::COBYLA {
             max_iter,
@@ -977,127 +1119,76 @@ impl<P: Problem> LocalSolver<P> {
             xtol_abs,
         } = solver_config
         {
-            // Convert initial point to Vec<f64> as required by COBYLA
-            let x0: Vec<f64> = initial_point.to_vec();
-
-            // Conditionally track function evaluations
-            let eval_count =
-                if track_evaluations { Some(Arc::new(AtomicU64::new(0))) } else { None };
-            let eval_count_for_closure = eval_count.clone();
-
-            // Create the objective function for COBYLA (needs 2 arguments: x and user_data)
-            let objective = move |x: &[f64], _user_data: &mut ()| -> f64 {
-                if let Some(ref counter) = eval_count_for_closure {
-                    counter.fetch_add(1, Ordering::Relaxed);
-                }
-                let point = Array1::from_vec(x.to_vec());
-
-                self.problem.objective(&point).unwrap_or(f64::INFINITY)
-            };
-
-            let constraint_dimension = Arc::new(OnceLock::new());
-            let initial_constraints =
-                evaluate_constraints(&self.problem, &initial_point, &constraint_dimension)
-                    .map_err(|error| LocalSolverError::RunFailed {
-                        solver_type: "COBYLA".to_string(),
-                        reason: error.to_string(),
-                    })?;
-            let constraint_count = initial_constraints.len();
-            let constraint_cache =
-                Arc::new(std::sync::Mutex::new(Some((x0.clone(), initial_constraints.to_vec()))));
-            let constraint_error = Arc::new(std::sync::Mutex::new(None));
-            let constraint_funcs: Vec<_> = (0..constraint_count)
-                .map(|index| {
-                    let constraint_cache = Arc::clone(&constraint_cache);
-                    let constraint_dimension = Arc::clone(&constraint_dimension);
-                    let constraint_error = Arc::clone(&constraint_error);
-
-                    move |x: &[f64], _user_data: &mut ()| -> f64 {
-                        let mut cache = constraint_cache
-                            .lock()
-                            .expect("COBYLA constraint cache mutex poisoned");
-                        let needs_evaluation = cache
-                            .as_ref()
-                            .is_none_or(|(cached_x, _): &(Vec<f64>, Vec<f64>)| cached_x != x);
-
-                        if needs_evaluation {
-                            let point = Array1::from_vec(x.to_vec());
-                            let values = match evaluate_constraints(
-                                &self.problem,
-                                &point,
-                                &constraint_dimension,
-                            ) {
-                                Ok(values) => values.to_vec(),
-                                Err(error) => {
-                                    *constraint_error
-                                        .lock()
-                                        .expect("COBYLA constraint error mutex poisoned") =
-                                        Some(error.to_string());
-                                    vec![f64::NEG_INFINITY; constraint_count]
-                                }
-                            };
-                            *cache = Some((x.to_vec(), values));
-                        }
-
-                        cache.as_ref().expect("constraint values were cached").1[index]
-                    }
-                })
-                .collect();
             let problem_bounds = self.problem.variable_bounds();
 
-            if problem_bounds.nrows() != x0.len() {
+            if problem_bounds.nrows() != initial_point.len() || problem_bounds.ncols() != 2 {
                 return Err(LocalSolverError::InvalidCOBYLAConfig {
                     reason: format!(
-                        "Problem bounds dimension mismatch: expected {} bounds for {} variables, got {} bounds",
-                        x0.len(),
-                        x0.len(),
-                        problem_bounds.nrows()
+                        "Problem bounds must have shape ({}, 2), got ({}, {}).",
+                        initial_point.len(),
+                        problem_bounds.nrows(),
+                        problem_bounds.ncols(),
                     ),
                 });
             }
 
-            let bounds: Vec<(f64, f64)> =
-                (0..x0.len()).map(|i| (problem_bounds[[i, 0]], problem_bounds[[i, 1]])).collect();
-
-            let result = cobyla::minimize(
-                objective,
-                &x0,
-                &bounds,
-                &constraint_funcs,
-                (),
-                *max_iter as usize,
-                cobyla::RhoBeg::All(*initial_step_size),
-                Some(cobyla::StopTols {
-                    ftol_rel: *ftol_rel,
-                    ftol_abs: *ftol_abs,
-                    xtol_rel: *xtol_rel,
-                    xtol_abs: if xtol_abs.is_empty() { vec![] } else { xtol_abs.clone() },
-                }),
-            );
-
-            if let Some(reason) =
-                constraint_error.lock().expect("COBYLA constraint error mutex poisoned").take()
-            {
-                return Err(LocalSolverError::RunFailed {
-                    solver_type: "COBYLA".to_string(),
-                    reason,
+            if !initial_step_size.is_finite() || *initial_step_size <= 0.0 {
+                return Err(LocalSolverError::InvalidCOBYLAConfig {
+                    reason: "`initial_step_size` must be finite and greater than zero.".to_string(),
                 });
             }
 
-            match result {
-                Ok((_status, solution_x, objective_value)) => {
-                    let solution_point = Array1::from_vec(solution_x);
-                    let solution =
-                        LocalSolution { point: solution_point, objective: objective_value };
-                    let evaluations =
-                        eval_count.as_ref().map(|c| c.load(Ordering::Relaxed)).unwrap_or(0);
-                    Ok((solution, evaluations))
-                }
-                Err(e) => Err(LocalSolverError::RunFailed {
-                    solver_type: "unknown".to_string(),
-                    reason: format!("COBYLA solver failed: {:?}", e),
-                }),
+            if !xtol_abs.is_empty() && xtol_abs.len() != initial_point.len() {
+                return Err(LocalSolverError::InvalidCOBYLAConfig {
+                    reason: format!(
+                        "`xtol_abs` must contain one tolerance per variable; expected {}, got {}.",
+                        initial_point.len(),
+                        xtol_abs.len(),
+                    ),
+                });
             }
+
+            let problem_constraint_count = self
+                .problem
+                .constraints(&initial_point)
+                .map_err(|error| LocalSolverError::RunFailed {
+                    solver_type: "COBYLA".to_string(),
+                    reason: error.to_string(),
+                })?
+                .len();
+            let objective_evaluations = Rc::new(Cell::new(0));
+            let problem = BasinProblem {
+                problem: &self.problem,
+                lower_bounds: problem_bounds.column(0).to_vec(),
+                upper_bounds: problem_bounds.column(1).to_vec(),
+                problem_constraint_count,
+                objective_evaluations: Rc::clone(&objective_evaluations),
+                max_objective_evaluations: *max_iter,
+            };
+            let rho_end = cobyla_rho_end(*initial_step_size, *xtol_rel, xtol_abs);
+            let solver = basin::Cobyla::new()
+                .with_initial_radius(*initial_step_size)
+                .with_final_radius(rho_end);
+            let mut cost_tolerance = CobylaCostTolerance::new(*ftol_rel, *ftol_abs);
+            // Despite its historical name, `max_iter` was passed to the former
+            // backend as its objective-evaluation budget.
+            let result = basin::Executor::from_start(problem, solver, initial_point.to_vec())
+                .max_iter(u64::MAX)
+                .max_cost_evals(*max_iter)
+                .stop_when(move |state| cost_tolerance.check(state))
+                .run()
+                .map_err(|error| LocalSolverError::RunFailed {
+                    solver_type: "COBYLA".to_string(),
+                    reason: error.to_string(),
+                })?;
+            ensure_cobyla_succeeded(result.reason)?;
+            let solution = LocalSolution {
+                point: Array1::from_vec(result.best_param().clone()),
+                objective: result.best_cost(),
+            };
+            let evaluations = if track_evaluations { objective_evaluations.get() } else { 0 };
+
+            Ok((solution, evaluations))
         } else {
             Err(LocalSolverError::InvalidCOBYLAConfig {
                 reason: "Error parsing solver configuration".to_string(),
@@ -1109,12 +1200,17 @@ impl<P: Problem> LocalSolver<P> {
 #[cfg(test)]
 mod tests_local_solvers {
     use super::*;
+    use crate::local_solver::builders::COBYLABuilder;
     #[cfg(feature = "argmin")]
     use crate::local_solver::builders::{
         HagerZhangBuilder, LBFGSBuilder, MoreThuenteBuilder, SteepestDescentBuilder,
     };
     use crate::types::{EvaluationError, LocalSolverType};
     use ndarray::{Array2, array};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    };
 
     #[derive(Debug, Clone)]
     pub struct NoGradientSixHumpCamel;
@@ -1146,6 +1242,104 @@ mod tests_local_solvers {
 
         fn constraints(&self, x: &Array1<f64>) -> Result<Array1<f64>, EvaluationError> {
             Ok(array![1.5 - x[0] - x[1]])
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct BoundConstrainedLinear;
+
+    impl Problem for BoundConstrainedLinear {
+        fn objective(&self, x: &Array1<f64>) -> Result<f64, EvaluationError> {
+            Ok(-x[0])
+        }
+
+        fn variable_bounds(&self) -> Array2<f64> {
+            array![[0.0, 1.0]]
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct BoundedDomain {
+        evaluations: Arc<AtomicU64>,
+        bounds: Array2<f64>,
+    }
+
+    impl Problem for BoundedDomain {
+        fn objective(&self, x: &Array1<f64>) -> Result<f64, EvaluationError> {
+            self.evaluations.fetch_add(1, Ordering::Relaxed);
+            assert!(
+                x.iter().all(|value| (0.0..=1.0).contains(value)),
+                "point {x:?} is outside the objective domain"
+            );
+            Ok(-x.iter().sum::<f64>())
+        }
+
+        fn constraints(&self, x: &Array1<f64>) -> Result<Array1<f64>, EvaluationError> {
+            assert!(
+                x.iter().all(|value| (0.0..=1.0).contains(value)),
+                "point {x:?} is outside the constraint domain"
+            );
+            Ok(Array1::zeros(0))
+        }
+
+        fn variable_bounds(&self) -> Array2<f64> {
+            self.bounds.clone()
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct FailingObjective;
+
+    impl Problem for FailingObjective {
+        fn objective(&self, _x: &Array1<f64>) -> Result<f64, EvaluationError> {
+            Err(EvaluationError::ObjectiveFunctionEvaluationFailed {
+                reason: "test failure".to_string(),
+            })
+        }
+
+        fn variable_bounds(&self) -> Array2<f64> {
+            array![[-1.0, 1.0]]
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct FailingConstraint;
+
+    impl Problem for FailingConstraint {
+        fn objective(&self, x: &Array1<f64>) -> Result<f64, EvaluationError> {
+            Ok(x[0].powi(2))
+        }
+
+        fn variable_bounds(&self) -> Array2<f64> {
+            array![[-1.0, 1.0]]
+        }
+
+        fn constraints(&self, x: &Array1<f64>) -> Result<Array1<f64>, EvaluationError> {
+            if x[0] > 0.0 {
+                Err(EvaluationError::ConstraintEvaluationFailed {
+                    index: 0,
+                    reason: "test failure".to_string(),
+                })
+            } else {
+                Ok(array![1.0])
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct VariableConstraintDimension;
+
+    impl Problem for VariableConstraintDimension {
+        fn objective(&self, x: &Array1<f64>) -> Result<f64, EvaluationError> {
+            Ok(-x[0])
+        }
+
+        fn variable_bounds(&self) -> Array2<f64> {
+            array![[-2.0, 2.0]]
+        }
+
+        fn constraints(&self, x: &Array1<f64>) -> Result<Array1<f64>, EvaluationError> {
+            if x[0] < 0.5 { Ok(array![1.0]) } else { Ok(Array1::zeros(0)) }
         }
     }
 
@@ -1652,6 +1846,215 @@ mod tests_local_solvers {
     }
 
     #[test]
+    fn test_cobyla_enforces_variable_bounds() {
+        let local_solver = LocalSolver::new(
+            BoundConstrainedLinear,
+            LocalSolverType::COBYLA,
+            COBYLABuilder::default().build(),
+        );
+
+        let solution = local_solver.solve(array![0.5]).unwrap();
+
+        assert!(solution.point[0] >= -1e-8);
+        assert!(solution.point[0] <= 1.0 + 1e-8);
+        assert!((solution.point[0] - 1.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_cobyla_does_not_evaluate_objective_outside_bounds() {
+        let local_solver = LocalSolver::new(
+            BoundedDomain { evaluations: Arc::new(AtomicU64::new(0)), bounds: array![[0.0, 1.0]] },
+            LocalSolverType::COBYLA,
+            LocalSolverConfig::COBYLA {
+                max_iter: 100,
+                initial_step_size: 0.5,
+                ftol_rel: 1e-6,
+                ftol_abs: 1e-8,
+                xtol_rel: 0.0,
+                xtol_abs: vec![],
+            },
+        );
+
+        let solution = local_solver.solve(array![0.75]).unwrap();
+
+        assert!((0.0..=1.0).contains(&solution.point[0]));
+    }
+
+    #[test]
+    fn test_cobyla_enforces_objective_evaluation_budget_during_initialization() {
+        let evaluations = Arc::new(AtomicU64::new(0));
+        let local_solver = LocalSolver::new(
+            BoundedDomain {
+                evaluations: Arc::clone(&evaluations),
+                bounds: Array2::from_shape_fn((5, 2), |(_, column)| column as f64),
+            },
+            LocalSolverType::COBYLA,
+            LocalSolverConfig::COBYLA {
+                max_iter: 1,
+                initial_step_size: 0.5,
+                ftol_rel: 0.0,
+                ftol_abs: 0.0,
+                xtol_rel: 0.0,
+                xtol_abs: vec![],
+            },
+        );
+
+        let (_, reported_evaluations) =
+            local_solver.solve_with_tracking(Array1::zeros(5), true).unwrap();
+
+        assert_eq!(evaluations.load(Ordering::Relaxed), 1);
+        assert_eq!(reported_evaluations, 1);
+    }
+
+    #[test]
+    fn test_cobyla_rejects_invalid_bounds_shape() {
+        for shape in [(0, 2), (2, 2), (1, 0), (1, 1), (1, 3)] {
+            let evaluations = Arc::new(AtomicU64::new(0));
+            let local_solver = LocalSolver::new(
+                BoundedDomain {
+                    evaluations: Arc::clone(&evaluations),
+                    bounds: Array2::zeros(shape),
+                },
+                LocalSolverType::COBYLA,
+                COBYLABuilder::default().build(),
+            );
+
+            let error = local_solver.solve(array![0.5]).unwrap_err();
+
+            assert_eq!(
+                error,
+                LocalSolverError::InvalidCOBYLAConfig {
+                    reason: format!(
+                        "Problem bounds must have shape (1, 2), got ({}, {}).",
+                        shape.0, shape.1,
+                    ),
+                }
+            );
+            assert_eq!(evaluations.load(Ordering::Relaxed), 0);
+        }
+    }
+
+    #[test]
+    fn test_cobyla_rejects_invalid_initial_step_size() {
+        for step_size in [0.0, -0.5, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let evaluations = Arc::new(AtomicU64::new(0));
+            let local_solver = LocalSolver::new(
+                BoundedDomain { evaluations: Arc::clone(&evaluations), bounds: array![[0.0, 1.0]] },
+                LocalSolverType::COBYLA,
+                COBYLABuilder::default().initial_step_size(step_size).build(),
+            );
+
+            let error = local_solver.solve(array![0.5]).unwrap_err();
+
+            assert_eq!(
+                error,
+                LocalSolverError::InvalidCOBYLAConfig {
+                    reason: "`initial_step_size` must be finite and greater than zero.".to_string(),
+                }
+            );
+            assert_eq!(evaluations.load(Ordering::Relaxed), 0);
+        }
+    }
+
+    #[test]
+    fn test_cobyla_rejects_invalid_xtol_abs_dimension() {
+        let local_solver = LocalSolver::new(
+            BoundConstrainedLinear,
+            LocalSolverType::COBYLA,
+            LocalSolverConfig::COBYLA {
+                max_iter: 100,
+                initial_step_size: 0.5,
+                ftol_rel: 1e-6,
+                ftol_abs: 1e-8,
+                xtol_rel: 0.0,
+                xtol_abs: vec![1e-6, 1e-6],
+            },
+        );
+
+        let error = local_solver.solve(array![0.5]).unwrap_err();
+
+        assert_eq!(
+            error,
+            LocalSolverError::InvalidCOBYLAConfig {
+                reason: "`xtol_abs` must contain one tolerance per variable; expected 1, got 2."
+                    .to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_cobyla_parameter_tolerances_determine_final_radius() {
+        assert_eq!(cobyla_rho_end(0.5, 1e-3, &[]), 5e-4);
+        assert_eq!(cobyla_rho_end(0.5, 1e-3, &[1e-2, 1e-4]), 1e-2);
+        assert_eq!(cobyla_rho_end(0.5, 0.0, &[]), f64::EPSILON.sqrt() * 0.5);
+    }
+
+    #[test]
+    fn test_cobyla_maps_solver_failure_termination_to_error() {
+        let error = ensure_cobyla_succeeded(basin::TerminationReason::SolverFailed).unwrap_err();
+
+        assert!(matches!(
+            error,
+            LocalSolverError::RunFailed { solver_type, reason }
+                if solver_type == "COBYLA" && reason.contains("SolverFailed")
+        ));
+    }
+
+    #[test]
+    fn test_cobyla_propagates_objective_errors() {
+        let local_solver = LocalSolver::new(
+            FailingObjective,
+            LocalSolverType::COBYLA,
+            COBYLABuilder::default().build(),
+        );
+
+        let error = local_solver.solve(array![0.0]).unwrap_err();
+
+        assert!(matches!(
+            error,
+            LocalSolverError::RunFailed { solver_type, reason }
+                if solver_type == "COBYLA" && reason.contains("test failure")
+        ));
+    }
+
+    #[test]
+    fn test_cobyla_propagates_constraint_errors() {
+        let local_solver = LocalSolver::new(
+            FailingConstraint,
+            LocalSolverType::COBYLA,
+            COBYLABuilder::default().build(),
+        );
+
+        // A positive start fails before solving; zero fails at a later simplex vertex.
+        for initial_point in [array![0.5], array![0.0]] {
+            let error = local_solver.solve(initial_point).unwrap_err();
+
+            assert!(matches!(
+                error,
+                LocalSolverError::RunFailed { solver_type, reason }
+                    if solver_type == "COBYLA" && reason.contains("test failure")
+            ));
+        }
+    }
+
+    #[test]
+    fn test_cobyla_rejects_constraint_dimension_changes() {
+        let local_solver = LocalSolver::new(
+            VariableConstraintDimension,
+            LocalSolverType::COBYLA,
+            COBYLABuilder::default().build(),
+        );
+
+        let error = local_solver.solve(array![0.0]).unwrap_err();
+
+        assert!(matches!(
+            error,
+            LocalSolverError::RunFailed { solver_type, reason }
+                if solver_type == "COBYLA" && reason.contains("expected 1 values, got 0")
+        ));
+    }
+
+    #[test]
     /// Test that constraint evaluation works correctly
     fn test_constraint_evaluation() {
         let problem = ConstrainedQuadratic;
@@ -1695,6 +2098,7 @@ mod tests_local_solvers {
             "COBYLA should track function evaluations when enabled, got {}",
             eval_count
         );
+        assert!(eval_count <= 100, "COBYLA exceeded its evaluation budget: {eval_count}");
         assert!(res.objective < 0.0);
 
         // Test with tracking disabled

--- a/src/observers/mod.rs
+++ b/src/observers/mod.rs
@@ -1096,7 +1096,7 @@ impl Observer {
     /// True if a callback is configured and the iteration is a multiple of
     /// the callback frequency.
     pub(crate) fn should_invoke_callback(&self, iteration: usize) -> bool {
-        self.callback.is_some() && (iteration % self.callback_frequency == 0)
+        self.callback.is_some() && iteration.is_multiple_of(self.callback_frequency)
     }
 }
 

--- a/src/oqnlp.rs
+++ b/src/oqnlp.rs
@@ -1585,7 +1585,7 @@ impl<P: Problem + Clone + Send + Sync> OQNLP<P> {
     #[cfg(feature = "checkpointing")]
     fn maybe_save_checkpoint(&self) -> Result<(), OQNLPError> {
         if let Some(ref manager) = self.checkpoint_manager {
-            if self.current_iteration % manager.config().save_frequency == 0 {
+            if self.current_iteration.is_multiple_of(manager.config().save_frequency) {
                 let checkpoint = self.create_checkpoint();
                 let saved_path = manager.save_checkpoint(&checkpoint, self.current_iteration)?;
 

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -139,9 +139,9 @@ pub trait Problem {
     ///
     /// Returns a `Result<Array2<f64>>` of the variable bounds for the optimization problem.
     ///
-    /// This bounds are only used in the scatter search phase of the algorithm.
-    /// The local solver is unconstrained (See [argmin issue #137](https://github.com/argmin-rs/argmin/issues/137)) and therefor can return solutions out of the bounds.
-    /// You may be able to guide your solutions to your desired bounds/constraints by using a penalty method.
+    /// COBYLA enforces these bounds during local optimization. The argmin-based
+    /// local solvers are unconstrained and can return solutions outside them; see
+    /// [argmin issue #137](https://github.com/argmin-rs/argmin/issues/137).
     fn variable_bounds(&self) -> Array2<f64>;
 
     /// Evaluates the constraints at `x`.


### PR DESCRIPTION
## Description

Replace the standalone `cobyla` crate with Basin 1.11.0's COBYLA implementation,
as discussed in #37. Existing Rust and Python COBYLA configurations now run
through a Basin adapter that handles vector constraints, variable bounds,
evaluation budgets, and convergence tolerances.

Basin's implementation is based PRIMA (https://github.com/libprima/prima),
unlike the cobyla crate, which uses the original Powell reference. So there are
a few differences here. In general it seems like Basin is somewhat slower for
smaller problems but faster for larger problems, and has slightly better
convergence behavior. I guess you'll have to decide whether you think the
tradeoff is worth it!

As discussed, this PR also raises the minimum supported Rust version from 1.85
to 1.87 for both crates. Solver trajectories and stopping behavior can change
with the new implementation.

I used Codex GPT-6 Astra to prepare part of this PR.

## Changes made

- Adapt the existing `c(x) >= 0` constraints to Basin's `c(x) <= 0` convention
  and represent variable bounds as additional inequalities. Project trial points
  into bounds before invoking user callbacks so objective and constraint
  functions can retain hard domain restrictions.
- Preserve `max_iter` as an objective-evaluation budget, including during
  simplex initialization, and retain evaluation tracking.
- Check function tolerances at changes in the trust-region radius to avoid
  stopping while COBYLA is improving its interpolation geometry. Map parameter
  tolerances to the final radius, with a positive numerical floor because Basin
  requires one even when user tolerances are disabled.
- Propagate objective and constraint errors, reject changing constraint
  dimensions, and validate bounds shape, initial step size, and nonempty
  `xtol_abs` lengths.
- Document the backend, tolerance behavior, and evaluation budget, and add
  regression coverage for the adapter.

## Benchmark observations

Measurements on six synthetic problems, with 30 seeds and six timing rounds on
one machine, show workload-dependent results. With default settings, Basin is
about 5.3 times faster for local solves with 100 constraints and 4.6 times
faster for the corresponding global search. Small Rosenbrock and six-hump camel
local solves are about 2.7 times slower.

Local success on six-hump camel improves from 14/30 to 18/30, and on the
two-constraint problem from 26/30 to 30/30, using objective-error and
feasibility thresholds of `1e-6`. Median local Rastrigin objective error
increases from about 4.97 to 6.96. Timings include adapter overhead and changes
in solver trajectories and evaluation counts, so these results do not establish
a general performance advantage.

## Validation

Focused checks after the final documentation and test updates:

- Python extension rebuilt with `maturin develop --release --locked`.
- `pytest tests/test_builders.py -q`: 8 passed, including the original custom
  tolerance values and partial-tolerances test.
- `cargo test --locked --doc COBYLABuilder`: 1 passed.
- Rust formatting checks for both crates and `git diff --check`: passed.

## Checklist

- [x] Documentation updated.
- [x] Regression tests cover the adapter changes.
- [x] Run the full Rust test suite on the final revision.
- [x] Complete Clippy verification on the final revision.

## Related issues

Refs #37
